### PR TITLE
Avoid pre-fetching when unsupported

### DIFF
--- a/src/pbrt/gpu/pathintegrator.cpp
+++ b/src/pbrt/gpu/pathintegrator.cpp
@@ -540,9 +540,8 @@ void GPURender(ParsedScene &scene) {
         // performance. (This makes it possible to use the values of things
         // like GPUPathIntegrator::haveSubsurface to conditionally launch
         // kernels according to what's in the scene...)
-
         CUDA_CHECK(cudaMemAdvise(integrator, sizeof(*integrator),
-                                 cudaMemAdviseSetReadMostly, 0));
+                                 cudaMemAdviseSetReadMostly, /* ignored argument */0));
         CUDA_CHECK(cudaMemAdvise(integrator, sizeof(*integrator),
                                  cudaMemAdviseSetPreferredLocation, deviceIndex));
 


### PR DESCRIPTION
`cudaMemAdvise()` and `cudaMemPrefetchAsync()` on GPU devices require those devices to have the `cudaDevAttrConcurrentManagedAccess` attribute set. Since pre-fetching is a performance optimisation and is not mandatory, only enable it when the attribute is set and skip it otherwise to avoid errors (see [this comment][0]).

[0]: https://github.com/mmp/pbrt-v4/issues/20#issuecomment-683182824