### PR TITLE
Rework PTX compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,10 +186,6 @@ if (CMAKE_CUDA_COMPILER)
 
         set (PBRT_CUDA_LIB cuda)
 
-        # optix
-        # FIXME
-        include_directories (${PBRT_OPTIX7_PATH}/include)
-
         # from Ingo's configure_optix.cmake (Apache licensed)
         find_program (BIN2C bin2c DOC "Path to the CUDA SDK bin2c executable.")
 
@@ -221,7 +217,7 @@ if (CMAKE_CUDA_COMPILER)
                 --define-macro=NDEBUG ${cuda_definitions}
                 )
           target_include_directories ("${lib_name}" PRIVATE src ${CMAKE_BINARY_DIR})
-          target_include_directories ("${lib_name}" SYSTEM PRIVATE ${NANOVDB_INCLUDE})
+          target_include_directories ("${lib_name}" SYSTEM PRIVATE ${NANOVDB_INCLUDE} ${PBRT_OPTIX7_PATH}/include)
           set (c_var_name ${output_var})
           set (embedded_file ${cuda_file}.ptx_embedded.c)
           add_custom_command (
@@ -696,6 +692,9 @@ target_include_directories (pbrt_lib PUBLIC
   ${NANOVDB_INCLUDE}
   ${CMAKE_CURRENT_BINARY_DIR}
 )
+if (PBRT_CUDA_ENABLED AND PBRT_OPTIX7_PATH)
+    target_include_directories (pbrt_lib SYSTEM PUBLIC ${PBRT_OPTIX7_PATH}/include)
+endif ()
 
 target_compile_options (pbrt_lib PUBLIC ${PBRT_CXX_FLAGS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,10 +189,6 @@ if (CMAKE_CUDA_COMPILER)
         # optix
         # FIXME
         include_directories (${PBRT_OPTIX7_PATH}/include)
-        # FIXME. Sigh. I'm not sure how else to pass this through to cuda_compile_ptx...
-        include_directories (src)
-        include_directories (${CMAKE_BINARY_DIR})
-        include_directories (${NANOVDB_INCLUDE})
 
         # from Ingo's configure_optix.cmake (Apache licensed)
         find_program (BIN2C bin2c DOC "Path to the CUDA SDK bin2c executable.")
@@ -207,21 +203,39 @@ if (CMAKE_CUDA_COMPILER)
         #    that PTX string 'embedded' as a global constant.
         # 4) assign the name of the intermediary .o file to the cmake variable
         #    'output_var', which can then be added to cmake targets.
-        macro (cuda_compile_and_embed output_var cuda_file)
+        macro (cuda_compile_and_embed output_var cuda_file lib_name)
+          add_library ("${lib_name}" OBJECT "${cuda_file}")
+          set_property (TARGET "${lib_name}" PROPERTY CUDA_PTX_COMPILATION ON)
+          set (cuda_definitions)
+          foreach (arg ${PBRT_DEFINITIONS})
+            list (APPEND cuda_definitions "--define-macro=${arg}")
+          endforeach ()
+          target_compile_options ("${lib_name}"
+            PRIVATE
+                -O3 --use_fast_math
+                # disable "extern declaration... is treated as a static definition" warning
+                -Xcudafe=--display_error_number -Xcudafe=--diag_suppress=3089
+                --gpu-architecture=${ARCH}
+                # using target_compile_definitions() does not do anything nor adding with -D, so use --define-macro instead.
+                # Possibly related to https://gitlab.kitware.com/cmake/cmake/-/issues/18765
+                --define-macro=NDEBUG ${cuda_definitions}
+                )
+          target_include_directories ("${lib_name}" PRIVATE src ${CMAKE_BINARY_DIR})
+          target_include_directories ("${lib_name}" SYSTEM PRIVATE ${NANOVDB_INCLUDE})
           set (c_var_name ${output_var})
-          cuda_compile_ptx (ptx_files ${cuda_file}
-                            OPTIONS --std=c++17 -O3 ${PBRT_CUDA_DIAG_FLAGS} -DNDEBUG --use_fast_math
-                                     # disable "extern declaration... is treated as a static definition" warning
-                                    -Xcudafe=--display_error_number -Xcudafe=--diag_suppress=3089
-                                    --gpu-architecture=${ARCH} -D PBRT_BUILD_GPU_RENDERER)
-          list (GET ptx_files 0 ptx_file)
-          set (embedded_file ${ptx_file}_embedded.c)
+          set (embedded_file ${cuda_file}.ptx_embedded.c)
           add_custom_command (
-            OUTPUT ${embedded_file}
-            COMMAND ${BIN2C} -c --padd 0 --type char --name ${c_var_name} ${ptx_file} > ${embedded_file}
-            DEPENDS ${ptx_file}
+            OUTPUT "${embedded_file}"
+            COMMAND ${CMAKE_COMMAND}
+              "-DBIN_TO_C_COMMAND=${BIN2C}"
+              "-DOBJECTS=$<TARGET_OBJECTS:${lib_name}>"
+              "-DVAR_NAME=${c_var_name}"
+              "-DOUTPUT=${embedded_file}"
+              -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/bin2c_wrapper.cmake
+            VERBATIM
+            DEPENDS $<TARGET_OBJECTS:${lib_name}>
             COMMENT "compiling (and embedding ptx from) ${cuda_file}"
-            )
+          )
           set (${output_var} ${embedded_file})
         endmacro ()
     endif ()
@@ -597,7 +611,7 @@ if (PBRT_CUDA_ENABLED)
     PROPERTIES LANGUAGE CUDA
   )
 
-  cuda_compile_and_embed (PBRT_EMBEDDED_PTX src/pbrt/gpu/optix.cu)
+  cuda_compile_and_embed (PBRT_EMBEDDED_PTX src/pbrt/gpu/optix.cu optix.cu)
 endif ()
 
 source_group("Source Files" FILES ${PBRT_SOURCE})

--- a/cmake/bin2c_wrapper.cmake
+++ b/cmake/bin2c_wrapper.cmake
@@ -1,0 +1,46 @@
+# Copyright (c) 1993-2015, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Taken from https://github.com/robertmaynard/code-samples/blob/master/posts/cmake_ptx/bin2c_wrapper.cmake
+# Modified to take a custom name instead of using the object name.
+
+set(file_contents)
+foreach(obj ${OBJECTS})
+  get_filename_component(obj_ext ${obj} EXT)
+  get_filename_component(obj_dir ${obj} DIRECTORY)
+
+  if(obj_ext MATCHES ".ptx")
+    set(args --name ${VAR_NAME} ${obj})
+    execute_process(COMMAND "${BIN_TO_C_COMMAND}" ${args}
+                    WORKING_DIRECTORY ${obj_dir}
+                    RESULT_VARIABLE result
+                    OUTPUT_VARIABLE output
+                    ERROR_VARIABLE error_var
+                    )
+    set(file_contents "${file_contents} \n${output}")
+  endif()
+endforeach()
+file(WRITE "${OUTPUT}" "${file_contents}")


### PR DESCRIPTION
* Rework the compilation to PTX to use the native CMake support via object libraries. This allows using scoped functions like `target_include_directories()` or `target_compile_options()` rather than the previous solution which required changing globally.
* Remove compilation flags that were defined more than once when compiling to PTX.
* Add `PBRT_DEFINITIONS` to the compilation flags when compiling to PTX, to solve the last bits of #27.
* Since the compilation to PTX no longer requires global includes, include OptiX using `target_include_directories()`.