### PR TITLE
fix GBufferFilm::GetImage() not applying output transform

### DIFF
--- a/src/pbrt/film.cpp
+++ b/src/pbrt/film.cpp
@@ -935,6 +935,7 @@ Image GBufferFilm::GetImage(ImageMetadata *metadata, Float splatScale) {
             rgb[c] += splatScale * pixel.splatRGB[c] / filterIntegral;
 
         rgb *= scale;
+        rgb = Mul<RGB>(outputRGBFromCameraRGB, rgb);
 
         Point2i pOffset(p.x - pixelBounds.pMin.x, p.y - pixelBounds.pMin.y);
         image.SetChannels(pOffset, rgbDesc, {rgb[0], rgb[1], rgb[2]});


### PR DESCRIPTION
This fixes GBufferFilm such that the following tests now match (modulo blackbody brightness differences):
simple/scenes/blp-texfilt.pbrt 
simple/scenes/blp-light-dragon-aov-path.pbrt 
simple/scenes/blp-simple.pbrt 
simple/scenes/gbuffer-xforms-coord-sys.pbrt