### PR TITLE
Removing previously deleted source file from CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,7 +514,6 @@ SET (PBRT_UTIL_SOURCE_HEADERS
   src/pbrt/util/rng.h
   src/pbrt/util/sampling.h
   src/pbrt/util/scattering.h
-  src/pbrt/util/shuffle.h
   src/pbrt/util/soa.h
   src/pbrt/util/sobolmatrices.h
   src/pbrt/util/spectrum.h


### PR DESCRIPTION
Solving the configuration error raised because of the removed file `util/shuffle.h` (commit 8578c81).