### PR TITLE
Avoid division by zero with flat ribbon curves

### DIFF
--- a/src/pbrt/shapes.cpp
+++ b/src/pbrt/shapes.cpp
@@ -647,10 +647,15 @@ bool Curve::RecursiveIntersect(const Ray &ray, Float tMax, pstd::span<const Poin
         Normal3f nHit;
         if (common->type == CurveType::Ribbon) {
             // Scale _hitWidth_ based on ribbon orientation
-            Float sin0 =
-                std::sin((1 - u) * common->normalAngle) * common->invSinNormalAngle;
-            Float sin1 = std::sin(u * common->normalAngle) * common->invSinNormalAngle;
-            nHit = sin0 * common->n[0] + sin1 * common->n[1];
+            if ( common->normalAngle == 0 )
+                nHit = common->n[0];
+            else {
+                Float sin0 =
+                    std::sin((1 - u) * common->normalAngle) * common->invSinNormalAngle;
+                Float sin1 =
+                    std::sin(u * common->normalAngle) * common->invSinNormalAngle;
+                nHit = sin0 * common->n[0] + sin1 * common->n[1];
+            }
             hitWidth *= AbsDot(nHit, ray.d) / rayLength;
         }
 


### PR DESCRIPTION
pbrt-v4 will crash when rendering a ribbon curve where both the start and end normal are the same value. When the angle between these two normals are 0 there is a division by 0 here -
https://github.com/mmp/pbrt-v4/blob/d6be103baa4e2c18c80af78662dce18e7f8b407e/src/pbrt/shapes.cpp#L471
Which later leads to a multiply by inf here -
https://github.com/mmp/pbrt-v4/blob/d6be103baa4e2c18c80af78662dce18e7f8b407e/src/pbrt/shapes.cpp#L650-L652

This fix avoids these values by simply using the ribbon curve's start normal as the nHit would be the same along the curve.

A test case which causes the crash is provided here -
[curve_crash.zip](https://github.com/mmp/pbrt-v4/files/5287539/curve_crash.zip)
