### PR TITLE
Avoid refinement depth calc for straight curves

### DIFF
--- a/src/pbrt/shapes.cpp
+++ b/src/pbrt/shapes.cpp
@@ -581,10 +581,13 @@ bool Curve::IntersectRay(const Ray &r, Float tMax,
                                   std::abs(cp[i].y - 2 * cp[i + 1].y + cp[i + 2].y)),
                          std::abs(cp[i].z - 2 * cp[i + 1].z + cp[i + 2].z)));
 
-    Float eps = std::max(common->width[0], common->width[1]) * .05f;  // width / 20
-    // Compute log base 4 by dividing log2 in half.
-    int r0 = Log2Int(1.41421356237f * 6.f * L0 / (8.f * eps)) / 2;
-    int maxDepth = Clamp(r0, 0, 10);
+    int maxDepth = 0;
+    if (L0 > 0) {
+        Float eps = std::max(common->width[0], common->width[1]) * .05f;  // width / 20
+        // Compute log base 4 by dividing log2 in half.
+        int r0 = Log2Int(1.41421356237f * 6.f * L0 / (8.f * eps)) / 2;
+        maxDepth = Clamp(r0, 0, 10);
+    }
 
     // Recursively test for ray--curve intersection
     pstd::span<const Point3f> cpSpan(cp);


### PR DESCRIPTION
In pbrt-v4 when we have a straight curve we can run into a case where L0 == 0
https://github.com/mmp/pbrt-v4/blob/d6be103baa4e2c18c80af78662dce18e7f8b407e/src/pbrt/shapes.cpp#L576-L582

When L0 is 0, a subsequent check within Log fails.
https://github.com/mmp/pbrt-v4/blob/d6be103baa4e2c18c80af78662dce18e7f8b407e/src/pbrt/util/math.h#L343

To avoid this issue, this fix avoids computing the refinement level and instead sets the max refinement depth to 0.

Attached is a sample scene which causes a fatal error
[straight_curve.zip](https://github.com/mmp/pbrt-v4/files/5287745/straight_curve.zip)
