### PR TITLE
Upgrading to latest nanovdb version.

### DIFF
--- a/src/pbrt/media.h
+++ b/src/pbrt/media.h
@@ -628,7 +628,7 @@ class NanoVDBMediumProvider {
             return SampledSpectrum(0.f);
         nanovdb::Vec3<float> pIndex =
             densityFloatGrid->worldToIndexF(nanovdb::Vec3<float>(p.x, p.y, p.z));
-        Float temp = nanovdb::TrilinearSampler(temperatureFloatGrid->tree())(pIndex);
+        Float temp = nanovdb::TrilinearSampler<nanovdb::FloatGrid::TreeType, false>(temperatureFloatGrid->tree())(pIndex);
         temp = (temp - temperatureCutoff) * temperatureScale;
         if (temp <= 100.f)
             return SampledSpectrum(0.f);
@@ -702,7 +702,7 @@ class NanoVDBMediumProvider {
     SampledSpectrum Density(const Point3f &p, const SampledWavelengths &lambda) const {
         nanovdb::Vec3<float> pIndex =
             densityFloatGrid->worldToIndexF(nanovdb::Vec3<float>(p.x, p.y, p.z));
-        Float density = nanovdb::TrilinearSampler(densityFloatGrid->tree())(pIndex);
+        Float density = nanovdb::TrilinearSampler<nanovdb::FloatGrid::TreeType, false>(densityFloatGrid->tree())(pIndex);
         return SampledSpectrum(density);
     }
 


### PR DESCRIPTION
Note: the volume files converted from OpenVDB to NanoVDB format need to be
converted again or it will cause GridMetadata errors.