### PR TITLE
Rework the compilation to PTX and embedding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,7 @@ find_package ( Threads )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if (MSVC)
-  add_definitions (/D _CRT_SECURE_NO_WARNINGS)
-  set(PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_IS_MSVC)
+  set(PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_IS_MSVC _CRT_SECURE_NO_WARNINGS)
 endif ()
 
 #######################################
@@ -189,10 +188,6 @@ if (CMAKE_CUDA_COMPILER)
         # optix
         # FIXME
         include_directories (${PBRT_OPTIX7_PATH}/include)
-        # FIXME. Sigh. I'm not sure how else to pass this through to cuda_compile_ptx...
-        include_directories (src)
-        include_directories (${CMAKE_BINARY_DIR})
-        include_directories (${NANOVDB_INCLUDE})
 
         # from Ingo's configure_optix.cmake (Apache licensed)
         find_program (BIN2C bin2c DOC "Path to the CUDA SDK bin2c executable.")
@@ -207,21 +202,32 @@ if (CMAKE_CUDA_COMPILER)
         #    that PTX string 'embedded' as a global constant.
         # 4) assign the name of the intermediary .o file to the cmake variable
         #    'output_var', which can then be added to cmake targets.
-        macro (cuda_compile_and_embed output_var cuda_file)
+        macro (cuda_compile_and_embed output_var cuda_file lib_name)
+          add_library ("${lib_name}" OBJECT "${cuda_file}")
+          set_property (TARGET "${lib_name}" PROPERTY CUDA_PTX_COMPILATION ON)
+          target_compile_options ("${lib_name}"
+            PRIVATE
+                # disable "extern declaration... is treated as a static definition" warning
+                -Xcudafe=--display_error_number -Xcudafe=--diag_suppress=3089
+                )
+          target_compile_definitions("${lib_name}" PRIVATE ${PBRT_DEFINITIONS})
+          target_include_directories ("${lib_name}" PRIVATE src ${CMAKE_BINARY_DIR})
+          target_include_directories ("${lib_name}" SYSTEM PRIVATE ${NANOVDB_INCLUDE})
+          add_dependencies ("${lib_name}" pbrt_soa_generated)
           set (c_var_name ${output_var})
-          cuda_compile_ptx (ptx_files ${cuda_file}
-                            OPTIONS --std=c++17 -O3 ${PBRT_CUDA_DIAG_FLAGS} -DNDEBUG --use_fast_math
-                                     # disable "extern declaration... is treated as a static definition" warning
-                                    -Xcudafe=--display_error_number -Xcudafe=--diag_suppress=3089
-                                    --gpu-architecture=${ARCH} -D PBRT_BUILD_GPU_RENDERER)
-          list (GET ptx_files 0 ptx_file)
-          set (embedded_file ${ptx_file}_embedded.c)
+          set (embedded_file ${cuda_file}.ptx_embedded.c)
           add_custom_command (
-            OUTPUT ${embedded_file}
-            COMMAND ${BIN2C} -c --padd 0 --type char --name ${c_var_name} ${ptx_file} > ${embedded_file}
-            DEPENDS ${ptx_file}
+            OUTPUT "${embedded_file}"
+            COMMAND ${CMAKE_COMMAND}
+              "-DBIN_TO_C_COMMAND=${BIN2C}"
+              "-DOBJECTS=$<TARGET_OBJECTS:${lib_name}>"
+              "-DVAR_NAME=${c_var_name}"
+              "-DOUTPUT=${embedded_file}"
+              -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/bin2c_wrapper.cmake
+            VERBATIM
+            DEPENDS "${lib_name}"
             COMMENT "compiling (and embedding ptx from) ${cuda_file}"
-            )
+          )
           set (${output_var} ${embedded_file})
         endmacro ()
     endif ()
@@ -597,7 +603,7 @@ if (PBRT_CUDA_ENABLED)
     PROPERTIES LANGUAGE CUDA
   )
 
-  cuda_compile_and_embed (PBRT_EMBEDDED_PTX src/pbrt/gpu/optix.cu)
+  cuda_compile_and_embed (PBRT_EMBEDDED_PTX src/pbrt/gpu/optix.cu optix.cu)
 endif ()
 
 source_group("Source Files" FILES ${PBRT_SOURCE})

--- a/cmake/bin2c_wrapper.cmake
+++ b/cmake/bin2c_wrapper.cmake
@@ -1,0 +1,46 @@
+# Copyright (c) 1993-2015, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Taken from https://github.com/robertmaynard/code-samples/blob/master/posts/cmake_ptx/bin2c_wrapper.cmake
+# Modified to take a custom name instead of using the object name.
+
+set(file_contents)
+foreach(obj ${OBJECTS})
+  get_filename_component(obj_ext ${obj} EXT)
+  get_filename_component(obj_dir ${obj} DIRECTORY)
+
+  if(obj_ext MATCHES ".ptx")
+    set(args --name ${VAR_NAME} ${obj})
+    execute_process(COMMAND "${BIN_TO_C_COMMAND}" ${args}
+                    WORKING_DIRECTORY ${obj_dir}
+                    RESULT_VARIABLE result
+                    OUTPUT_VARIABLE output
+                    ERROR_VARIABLE error_var
+                    )
+    set(file_contents "${file_contents} \n${output}")
+  endif()
+endforeach()
+file(WRITE "${OUTPUT}" "${file_contents}")

--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -1,6 +1,10 @@
 
 cmake_minimum_required (VERSION 3.12)
 
+if (MSVC)
+  add_definitions(/D _CRT_SECURE_NO_WARNINGS)
+endif ()
+
 ###########################################################################
 # stb
 


### PR DESCRIPTION
Since we have a CMake target, we can do scoped include directories.
Remove duplicate compile flags, and also add compile definitions which
enables PBRT to compile on Windows for Pascal-architecture cards.

Compared to commit a685e0205e433cefe99e13ab36ca340eb7bdfdf6, this also

* changes the dependency to be directly on the library rather than some of its object file;
* adds a missing dependency on several generated header files;
* avoids passing `/D _CRT_SECURE_NO_WARNINGS` to nvcc;
* removes compiler flags that are part of the regular CUDA flags.