### PR TITLE
RGBSigmoidPolynomial: use an exact inverse mapping for uniform colors

### DIFF
--- a/src/pbrt/util/color.cpp
+++ b/src/pbrt/util/color.cpp
@@ -35,13 +35,18 @@ RGBSigmoidPolynomial RGBToSpectrumTable::operator()(const RGB &rgb) const {
     CHECK(rgb[0] >= 0.f && rgb[1] >= 0.f && rgb[2] >= 0.f && rgb[0] <= 1.f &&
           rgb[1] <= 1.f && rgb[2] <= 1.f);
 
-    // Find largest RGB component and handle black _rgb_
+    /// Analytic solution for uniform RGB values
+    if (rgb[0] == rgb[1] && rgb[1] == rgb[2]) {
+        Float v = rgb[0],
+              inv = (v - .5f) / std::sqrt(v*(1.f - v));
+        return {Float(0), Float(0), inv};
+    }
+
+    // Find largest RGB component
     int i = 0;
     for (int j = 1; j < 3; ++j)
         if (rgb[j] >= rgb[i])
             i = j;
-    if (rgb[i] == 0)
-        return {Float(0), Float(0), -std::numeric_limits<Float>::infinity()};
 
     // Compute floating-point offsets into polynomial coefficient table
     float z = rgb[i], sc = (res - 1) / z, x = rgb[(i + 1) % 3] * sc,


### PR DESCRIPTION
This PR fixes #54 and #28. As the albedo closely approaches 1, the sigmoid coefficients can vary significantly wrt. small perturbations in the chroma dimension, making them difficult to interpolate with sufficient accuracy. In the reported case, the following spectrum was returned for an albedo of (1, 1, 1), which is clearly undesirable:

<img width="418" alt="screenshot" src="https://user-images.githubusercontent.com/1203629/95865476-06b12f80-0d67-11eb-8f5b-1bd04c8f0e4c.png">

The EGSR paper introducing the sigmoid spectra proposes the use of a higher resolution around the extremes (albedo == 0, albedo == 1), and this addresses the issue when reducing the albedo by even a fraction of a percent. But it is not going to fix the very extremes. This PR extends an existing special case present in the code (for albedo = (0, 0, 0)) to handle not just perfectly white/black values, but all intermediate grayscale ones as well. The used analytic inverse produces +/- inf as desired for the extremes.