### PR TITLE
Specify macros as compile flags with Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,24 @@ if (CMAKE_CUDA_COMPILER)
                 # disable "extern declaration... is treated as a static definition" warning
                 -Xcudafe=--display_error_number -Xcudafe=--diag_suppress=3089
                 )
-          target_compile_definitions("${lib_name}" PRIVATE ${PBRT_DEFINITIONS})
+          # CUDA integration in Visual Studio seems broken as even if "Use
+          # Host Preprocessor Definitions" is checked, the host preprocessor
+          # definitions are still not used when compiling device code.
+          # To work around that, define the macros using --define-macro to
+          # avoid CMake identifying those as macros and using the proper (but
+          # broken) way of specifying them.
+          if (${CMAKE_GENERATOR} MATCHES "^Visual Studio")
+            # As NDEBUG is specified globally as a definition, we need to
+            # manually add it due to the bug mentioned earlier and due to it
+            # not being found in PBRT_DEFINITIONS.
+            set (cuda_definitions "--define-macro=NDEBUG")
+            foreach (arg ${PBRT_DEFINITIONS})
+              list (APPEND cuda_definitions "--define-macro=${arg}")
+            endforeach ()
+            target_compile_options("${lib_name}" PRIVATE ${cuda_definitions})
+          else ()
+            target_compile_definitions("${lib_name}" PRIVATE ${PBRT_DEFINITIONS})
+          endif()
           target_include_directories ("${lib_name}" PRIVATE src ${CMAKE_BINARY_DIR})
           target_include_directories ("${lib_name}" SYSTEM PRIVATE ${NANOVDB_INCLUDE})
           add_dependencies ("${lib_name}" pbrt_soa_generated)


### PR DESCRIPTION
CUDA integration in Visual Studio seems broken as even if "Use Host Preprocessor Definitions" is checked, the host preprocessor definitions are still not used when compiling device code.
I tried creating a new CUDA project using the CUDA project templates in Visual Studio, to avoid having CMake in the equation, and experienced the same issue there so it really seems like CMake is setting up the project properly but the Visual Studio CUDA integration is ignoring the "Use Host Preprocessor Definitions" option.

First you can see that host definitions are marked for usage with device code
![Screenshot of the optix.cu properties in Visual Studio showing host definitions and them being marked as to-be-used for device code too](https://user-images.githubusercontent.com/9851680/96838428-2b349800-1448-11eb-802e-da8a9f338080.png)

However despite that, the host definitions do not show up on the command line when compiling device code but do only for host code
![Screenshot of the optix.cu properties in Visual Studio showing the command lines used for compiling device and host code, and the presence of host definitions only when compiling host code despite having checked the "Use Host Preprocessor Definitions"](https://user-images.githubusercontent.com/9851680/96838644-69ca5280-1448-11eb-9e4b-5ca8c47da48d.png)

To work around that, define the macros using --define-macro to avoid CMake identifying those as macros and using the proper (but broken) way of specifying them, so that they get added as regular compilation flags instead.