### PR TITLE
Fix flip build on windows

### DIFF
--- a/src/ext/flip/flip.cpp
+++ b/src/ext/flip/flip.cpp
@@ -462,13 +462,7 @@ public:
 
 // flip.cpp
 
-#include <iostream>
-#include <fstream>
-#include <string>
-#include <vector>
 #include <algorithm>
-#define _USE_MATH_DEFINES
-#include <cmath>
 
 namespace flip_detail {
 

--- a/src/ext/flip/flip.cpp
+++ b/src/ext/flip/flip.cpp
@@ -37,11 +37,14 @@
 
 // pooling.h
 
+#ifdef WIN32
+#define _USE_MATH_DEFINES
+#endif
+#include <cmath>
 #include <vector>
 #include <string>
 #include <sstream>
 #include <iomanip>
-#include <cmath>
 #include <iostream>
 #include <fstream>
 #include <cassert>


### PR DESCRIPTION
_USE_MATH_DEFINES needs to be defined, right before cmath is included, on Windows for M_PI to be available.

Fixes #66 ("ꟻLIP compilation failure on Windows due to undefined symbol M_PI")