### PR TITLE
Small improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ if (CMAKE_CUDA_COMPILER)
               "-DOUTPUT=${embedded_file}"
               -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/bin2c_wrapper.cmake
             VERBATIM
-            DEPENDS "${lib_name}"
+            DEPENDS "${lib_name}" $<TARGET_OBJECTS:${lib_name}>
             COMMENT "compiling (and embedding ptx from) ${cuda_file}"
           )
           set (${output_var} ${embedded_file})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ if (CMAKE_CUDA_COMPILER)
               -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/bin2c_wrapper.cmake
             VERBATIM
             DEPENDS "${lib_name}" $<TARGET_OBJECTS:${lib_name}>
-            COMMENT "compiling (and embedding ptx from) ${cuda_file}"
+            COMMENT "Embedding PTX generated from ${cuda_file}"
           )
           set (${output_var} ${embedded_file})
         endmacro ()

--- a/src/pbrt/gpu/accel.cpp
+++ b/src/pbrt/gpu/accel.cpp
@@ -597,7 +597,8 @@ GPUAccel::GPUAccel(
 #endif
     OPTIX_CHECK(optixDeviceContextCreate(cudaContext, &ctxOptions, &optixContext));
 
-    LOG_VERBOSE("Optix version %d successfully initialized", OPTIX_VERSION);
+    LOG_VERBOSE("Optix version %d.%d.%d successfully initialized", OPTIX_VERSION / 10000,
+                (OPTIX_VERSION % 10000) / 100, OPTIX_VERSION % 100);
 
     // OptiX module
     OptixModuleCompileOptions moduleCompileOptions = {};

--- a/src/pbrt/gpu/accel.cpp
+++ b/src/pbrt/gpu/accel.cpp
@@ -587,9 +587,9 @@ GPUAccel::GPUAccel(
     OPTIX_CHECK(optixInit());
     OptixDeviceContextOptions ctxOptions = {};
 #ifndef NDEBUG
-    ctxOptions.logCallbackLevel = 2; // error
+    ctxOptions.logCallbackLevel = 4;  // status/progress
 #else
-    ctxOptions.logCallbackLevel = 4; // status/progress
+    ctxOptions.logCallbackLevel = 2;  // error
 #endif
     ctxOptions.logCallbackFunction = logCallback;
 #if (OPTIX_VERSION >= 70200)


### PR DESCRIPTION
Just a few improvements regarding OptiX

* showing the version as major.minor.micro,
* and using a higher log level in debug builds

and CMake

* ensuring that embedding of the PTX always run after the PTX is re-generated,
* and updating the comment of the embedding command to reflect that it only does embedding