### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,8 @@ endif ()
 #########################################
 ## CUDA / OptiX
 
+add_library (cuda_build_configuration INTERFACE)
+
 include (CheckLanguage)
 
 check_language(CUDA)
@@ -150,14 +152,17 @@ if (CMAKE_CUDA_COMPILER)
         set (PBRT_CUDA_DIAG_FLAGS "${PBRT_CUDA_DIAG_FLAGS} -Xcudafe --diag_suppress=declared_but_not_referenced")
         # WAR invalid warnings about this with "if constexpr"
         set (PBRT_CUDA_DIAG_FLAGS "${PBRT_CUDA_DIAG_FLAGS} -Xcudafe --diag_suppress=implicit_return_from_non_void_function")
-        set (PBRT_CUDA_DIAG_FLAGS "${PBRT_CUDA_DIAG_FLAGS} --expt-relaxed-constexpr")
-        set (PBRT_CUDA_DIAG_FLAGS "${PBRT_CUDA_DIAG_FLAGS} --extended-lambda")
         set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${PBRT_CUDA_DIAG_FLAGS}")
 
         # Willie hears yeh..
         set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xnvlink -suppress-stack-size-warning")
 
-        set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --forward-unknown-to-host-compiler")
+        target_compile_options (
+            cuda_build_configuration
+            INTERFACE
+                "$<$<COMPILE_LANGUAGE:CUDA>:--std=c++17;--use_fast_math;--expt-relaxed-constexpr;--extended-lambda;--forward-unknown-to-host-compiler>"
+                "$<$<COMPILE_LANGUAGE:CUDA>:$<IF:$<CONFIG:Debug>,-G;-g,-lineinfo;-maxrregcount;128>>"
+        )
 
         # https://wagonhelm.github.io/articles/2018-03/detecting-cuda-capability-with-cmake
         # Get CUDA compute capability
@@ -171,13 +176,6 @@ if (CMAKE_CUDA_COMPILER)
         execute_process (COMMAND ${CHECK_CUDA_OUTPUT_EXE}
                          RESULT_VARIABLE CUDA_RETURN_CODE
                          OUTPUT_VARIABLE CHECK_CUDA_OUTPUT)
-
-        set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std=c++17")
-        if (CMAKE_BUILD_TYPE MATCHES Debug)
-          set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math -G -g")
-        else()
-          set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math -lineinfo -maxrregcount 128")
-        endif ()
 
         if (NOT ${CUDA_RETURN_CODE} EQUAL 0)
             message (SEND_ERROR ${CHECK_CUDA_OUTPUT})
@@ -233,6 +231,7 @@ if (CMAKE_CUDA_COMPILER)
           endif()
           target_include_directories ("${lib_name}" PRIVATE src ${CMAKE_BINARY_DIR})
           target_include_directories ("${lib_name}" SYSTEM PRIVATE ${NANOVDB_INCLUDE})
+          target_link_libraries ("${lib_name}" PRIVATE cuda_build_configuration)
           add_dependencies ("${lib_name}" pbrt_soa_generated)
           set (c_var_name ${output_var})
           set (embedded_file ${cuda_file}.ptx_embedded.c)
@@ -717,6 +716,10 @@ if (PBRT_CUDA_ENABLED AND PBRT_OPTIX7_PATH)
 endif ()
 
 target_compile_options (pbrt_lib PUBLIC ${PBRT_CXX_FLAGS})
+
+if (PBRT_CUDA_ENABLED)
+    target_link_libraries (pbrt_lib PRIVATE cuda_build_configuration)
+endif ()
 
 add_sanitizers (pbrt_lib)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ target_compile_options (
         "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4244>" # int -> float conversion
         "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4267>" # size_t -> int conversion
         "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4305>" # double constant assigned to float
+        "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4552>" # result of expression not used
         "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4838>" # double -> int conversion
         "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4843>" # double -> float conversion
         "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd26451>" # arithmetic on 4-byte value, then cast to 8-byte

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,10 @@ if (MSVC)
   set(PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_IS_MSVC _CRT_SECURE_NO_WARNINGS)
 endif ()
 
+if (PBRT_FLOAT_AS_DOUBLE)
+  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_FLOAT_AS_DOUBLE)
+endif ()
+
 #######################################
 ## ext
 
@@ -253,10 +257,6 @@ if (CMAKE_CUDA_COMPILER)
     endif ()
 else ()
     message (STATUS "CUDA not found")
-endif ()
-
-if (PBRT_FLOAT_AS_DOUBLE)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_FLOAT_AS_DOUBLE)
 endif ()
 
 ###########################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,8 @@ if (CMAKE_CUDA_COMPILER)
             cuda_build_configuration
             INTERFACE
                 "$<$<COMPILE_LANGUAGE:CUDA>:--std=c++17;--use_fast_math;--expt-relaxed-constexpr;--extended-lambda;--forward-unknown-to-host-compiler>"
-                "$<$<COMPILE_LANGUAGE:CUDA>:$<IF:$<CONFIG:Debug>,-G;-g,-lineinfo;-maxrregcount;128>>"
+                # The "$<NOT:$<BOOL:$<TARGET_PROPERTY:CUDA_PTX_COMPILATION>>>" part is to not add debugging symbols when generating PTX files for OptiX; see https://github.com/mmp/pbrt-v4/issues/69#issuecomment-715499748.
+                "$<$<COMPILE_LANGUAGE:CUDA>:$<IF:$<AND:$<CONFIG:Debug>,$<NOT:$<BOOL:$<TARGET_PROPERTY:CUDA_PTX_COMPILATION>>>>,-G;-g,-lineinfo;-maxrregcount;128>>"
         )
 
         # https://wagonhelm.github.io/articles/2018-03/detecting-cuda-capability-with-cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,19 @@ else ()
   message (STATUS "Found -lprofiler: ${PROFILE_LIB}")
 endif ()
 
+add_library (pbrt_warnings INTERFACE)
+target_compile_options (
+    pbrt_warnings
+    INTERFACE
+        "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4244>" # int -> float conversion
+        "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4267>" # size_t -> int conversion
+        "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4305>" # double constant assigned to float
+        "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4838>" # double -> int conversion
+        "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd4843>" # double -> float conversion
+        "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd26451>" # arithmetic on 4-byte value, then cast to 8-byte
+        "$<$<CXX_COMPILER_ID:MSVC>:$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler >/wd26495>" # uninitialized member variable
+)
+
 #########################################
 ## CUDA / OptiX
 
@@ -148,15 +161,17 @@ if (CMAKE_CUDA_COMPILER)
         include_directories (${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})  # for regular c++ compiles
 
         # http://www.ssl.berkeley.edu/~jimm/grizzly_docs/SSL/opt/intel/cc/9.0/lib/locale/en_US/mcpcom.msg
-        set (PBRT_CUDA_DIAG_FLAGS "")
-        #set (PBRT_CUDA_DIAG_FLAGS "${PBRT_CUDA_DIAG_FLAGS} -Xptxas --warn-on-double-precision-use")
-        set (PBRT_CUDA_DIAG_FLAGS "${PBRT_CUDA_DIAG_FLAGS} -Xcudafe --diag_suppress=partial_override")
-        set (PBRT_CUDA_DIAG_FLAGS "${PBRT_CUDA_DIAG_FLAGS} -Xcudafe --diag_suppress=virtual_function_decl_hidden")
-        set (PBRT_CUDA_DIAG_FLAGS "${PBRT_CUDA_DIAG_FLAGS} -Xcudafe --diag_suppress=integer_sign_change")
-        set (PBRT_CUDA_DIAG_FLAGS "${PBRT_CUDA_DIAG_FLAGS} -Xcudafe --diag_suppress=declared_but_not_referenced")
-        # WAR invalid warnings about this with "if constexpr"
-        set (PBRT_CUDA_DIAG_FLAGS "${PBRT_CUDA_DIAG_FLAGS} -Xcudafe --diag_suppress=implicit_return_from_non_void_function")
-        set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${PBRT_CUDA_DIAG_FLAGS}")
+        target_compile_options (
+            pbrt_warnings
+            INTERFACE
+                #"$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas --warn-on-double-precision-use>"
+                "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=partial_override>"
+                "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=virtual_function_decl_hidden>"
+                "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=integer_sign_change>"
+                "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=declared_but_not_referenced>"
+                # WAR invalid warnings about this with "if constexpr"
+                "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=implicit_return_from_non_void_function>"
+        )
 
         # Willie hears yeh..
         set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xnvlink -suppress-stack-size-warning")
@@ -236,7 +251,7 @@ if (CMAKE_CUDA_COMPILER)
           endif()
           target_include_directories ("${lib_name}" PRIVATE src ${CMAKE_BINARY_DIR})
           target_include_directories ("${lib_name}" SYSTEM PRIVATE ${NANOVDB_INCLUDE})
-          target_link_libraries ("${lib_name}" PRIVATE cuda_build_configuration)
+          target_link_libraries ("${lib_name}" PRIVATE cuda_build_configuration pbrt_warnings)
           add_dependencies ("${lib_name}" pbrt_soa_generated)
           set (c_var_name ${output_var})
           set (embedded_file ${cuda_file}.ptx_embedded.c)
@@ -295,17 +310,6 @@ endif ()
 
 if (MSVC AND MSVC_VERSION LESS 1920)
   message (SEND_ERROR "pbrt-v4 currently requires MSVC 2019 to build on Windows. PRs that get MSVC 2017 working as well would be welcomed. :-)")
-endif ()
-
-if (MSVC AND NOT PBRT_CUDA_ENABLED)
-  # FIXME: it would be nice to still pipe these through to MSVC in this case.
-  list (APPEND PBRT_CXX_FLAGS /wd4305) # double constant assigned to float
-  list (APPEND PBRT_CXX_FLAGS /wd4244) # int -> float conversion
-  list (APPEND PBRT_CXX_FLAGS /wd4843) # double -> float conversion
-  list (APPEND PBRT_CXX_FLAGS /wd4267) # size_t -> int conversion
-  list (APPEND PBRT_CXX_FLAGS /wd4838) # double -> int conversion
-  list (APPEND PBRT_CXX_FLAGS /wd26495) # uninitialized member variable
-  list (APPEND PBRT_CXX_FLAGS /wd26451) # arithmetic on 4-byte value, then cast to 8-byte
 endif ()
 
 ###########################################################################
@@ -652,6 +656,7 @@ add_executable (pbrt::soac ALIAS soac)
 
 target_compile_definitions (soac PRIVATE ${PBRT_DEFINITIONS})
 target_compile_options (soac PUBLIC ${PBRT_CXX_FLAGS})
+target_link_libraries (soac PRIVATE pbrt_warnings)
 
 set_target_properties (soac PROPERTIES OUTPUT_NAME soac)
 
@@ -718,9 +723,7 @@ endif ()
 
 target_compile_options (pbrt_lib PUBLIC ${PBRT_CXX_FLAGS})
 
-if (PBRT_CUDA_ENABLED)
-    target_link_libraries (pbrt_lib PRIVATE cuda_build_configuration)
-endif ()
+target_link_libraries (pbrt_lib PRIVATE pbrt_warnings $<$<BOOL:PBRT_CUDA_ENABLED>:cuda_build_configuration>)
 
 add_sanitizers (pbrt_lib)
 
@@ -764,7 +767,7 @@ add_executable (pbrt::rgb2spec_opt ALIAS rgb2spec_opt)
 
 target_compile_definitions (rgb2spec_opt PRIVATE ${PBRT_DEFINITIONS})
 target_compile_options (rgb2spec_opt PUBLIC ${PBRT_CXX_FLAGS})
-target_link_libraries (rgb2spec_opt ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries (rgb2spec_opt PRIVATE ${CMAKE_THREAD_LIBS_INIT} pbrt_warnings)
 
 add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/rgbspectrum_aces.cpp
     COMMAND rgb2spec_opt 64 ${CMAKE_CURRENT_BINARY_DIR}/rgbspectrum_aces.cpp ACES2065_1 
@@ -791,7 +794,7 @@ add_executable (pbrt::pbrt_exe ALIAS pbrt_exe)
 target_compile_definitions (pbrt_exe PRIVATE ${PBRT_DEFINITIONS})
 target_compile_options (pbrt_exe PRIVATE ${PBRT_CXX_FLAGS})
 target_include_directories (pbrt_exe PRIVATE src src/ext)
-target_link_libraries (pbrt_exe PRIVATE ${ALL_PBRT_LIBS})
+target_link_libraries (pbrt_exe PRIVATE ${ALL_PBRT_LIBS} pbrt_warnings)
 
 set_target_properties (pbrt_exe PROPERTIES OUTPUT_NAME pbrt)
 
@@ -809,7 +812,7 @@ set_property (TARGET sky_lib PROPERTY FOLDER "ext")
 target_compile_definitions (imgtool PRIVATE ${PBRT_DEFINITIONS})
 target_compile_options (imgtool PRIVATE ${PBRT_CXX_FLAGS})
 target_include_directories (imgtool PRIVATE src src/ext ${FLIP_INCLUDE} )
-target_link_libraries (imgtool PRIVATE ${ALL_PBRT_LIBS} sky_lib flip_lib)
+target_link_libraries (imgtool PRIVATE ${ALL_PBRT_LIBS} pbrt_warnings sky_lib flip_lib)
 
 add_sanitizers (imgtool)
 
@@ -820,6 +823,7 @@ add_executable (obj2pbrt src/pbrt/cmd/obj2pbrt.cpp)
 
 target_compile_definitions (obj2pbrt PRIVATE ${PBRT_DEFINITIONS})
 target_compile_options (obj2pbrt PRIVATE ${PBRT_CXX_FLAGS})
+target_link_libraries (obj2pbrt PRIVATE pbrt_warnings)
 
 add_sanitizers (obj2pbrt)
 
@@ -830,6 +834,7 @@ add_executable (cyhair2pbrt src/pbrt/cmd/cyhair2pbrt.cpp)
 
 target_compile_definitions (cyhair2pbrt PRIVATE ${PBRT_DEFINITIONS})
 target_compile_options (cyhair2pbrt PRIVATE ${PBRT_CXX_FLAGS})
+target_link_libraries (cyhair2pbrt PRIVATE pbrt_warnings)
 
 add_sanitizers (cyhair2pbrt)
 
@@ -872,7 +877,7 @@ set (PBRT_TEST_SOURCE
 
 add_executable (pbrt_test src/pbrt/cmd/pbrt_test.cpp ${PBRT_TEST_SOURCE})
 
-target_link_libraries (pbrt_test PRIVATE ${ALL_PBRT_LIBS})
+target_link_libraries (pbrt_test PRIVATE ${ALL_PBRT_LIBS} pbrt_warnings)
 target_compile_definitions (pbrt_test PRIVATE ${PBRT_DEFINITIONS})
 target_include_directories (pbrt_test PRIVATE src src/ext ${DOUBLE_CONVERSION_INCLUDE})
 target_compile_options(pbrt_test PUBLIC ${PBRT_CXX_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # For sanitizers
-set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+list (PREPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 # Configuration options
 
@@ -75,11 +75,11 @@ find_package ( Threads )
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if (MSVC)
-  set(PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_IS_MSVC _CRT_SECURE_NO_WARNINGS)
+  list (APPEND PBRT_DEFINITIONS "PBRT_IS_MSVC" "_CRT_SECURE_NO_WARNINGS")
 endif ()
 
 if (PBRT_FLOAT_AS_DOUBLE)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_FLOAT_AS_DOUBLE)
+  list (APPEND PBRT_DEFINITIONS "PBRT_FLOAT_AS_DOUBLE")
 endif ()
 
 #######################################
@@ -93,14 +93,14 @@ add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/src/ext)
 # os/compiler-specific stuff
 
 if (CMAKE_SYSTEM_NAME STREQUAL Windows)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_IS_WINDOWS NOMINMAX)
+  list (APPEND PBRT_DEFINITIONS "PBRT_IS_WINDOWS" "NOMINMAX")
 elseif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_IS_OSX)
+  list (APPEND PBRT_DEFINITIONS "PBRT_IS_OSX")
 elseif (CMAKE_SYSTEM_NAME STREQUAL Linux)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_IS_LINUX)
+  list (APPEND PBRT_DEFINITIONS "PBRT_IS_LINUX")
   # -rdynamic so we can get backtrace symbols...
   # --no-as-needed so libprofiler sticks around
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic -Wl,--no-as-needed")
+  string (APPEND CMAKE_EXE_LINKER_FLAGS " -rdynamic -Wl,--no-as-needed")
 else ()
   message (SEND_ERROR "Unknown system name: " + CMAKE_SYSTEM_NAME)
 endif()
@@ -154,8 +154,8 @@ if (CMAKE_CUDA_COMPILER)
         message (WARNING "Found CUDA but PBRT_OPTIX7_PATH is not set. Disabling GPU compilation.")
     else ()
         enable_language (CUDA)
-        set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_BUILD_GPU_RENDERER)
-        set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} NVTX)
+        list (APPEND PBRT_DEFINITIONS "PBRT_BUILD_GPU_RENDERER")
+        list (APPEND PBRT_DEFINITIONS "NVTX")
         set (PBRT_CUDA_ENABLED ON)
 
         # FIXME
@@ -175,7 +175,7 @@ if (CMAKE_CUDA_COMPILER)
         )
 
         # Willie hears yeh..
-        set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xnvlink -suppress-stack-size-warning")
+        string (APPEND CMAKE_CUDA_FLAGS " -Xnvlink -suppress-stack-size-warning")
 
         target_compile_options (
             cuda_build_configuration
@@ -203,7 +203,7 @@ if (CMAKE_CUDA_COMPILER)
           else ()
             set(ARCH "${CHECK_CUDA_OUTPUT}")
             message (STATUS "CUDA Architecture: ${ARCH}")
-            set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --gpu-architecture=${ARCH}")
+            string (APPEND CMAKE_CUDA_FLAGS " --gpu-architecture=${ARCH}")
         endif ()
 
         set (PBRT_CUDA_LIB cuda)
@@ -283,11 +283,11 @@ INCLUDE(CheckCXXCompilerFlag)
 # TODO: how to specify this on windows?
 check_cxx_compiler_flag ("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
 if (COMPILER_SUPPORTS_MARCH_NATIVE AND PBRT_BUILD_NATIVE_EXECUTABLE)
-  list (APPEND PBRT_CXX_FLAGS -march=native)
+  list (APPEND PBRT_CXX_FLAGS "-march=native")
 endif ()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-  list(APPEND PBRT_CXX_FLAGS -std=c++17)
+  list (APPEND PBRT_CXX_FLAGS "-std=c++17")
 
   FIND_PROGRAM(XIAR xiar)
   IF(XIAR)
@@ -306,7 +306,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   set(FP_MODEL "precise" CACHE STRING "The floating point model to compile with.")
   set_property(CACHE FP_MODEL PROPERTY STRINGS "precise" "fast=1" "fast=2")
 
-  list (APPEND PBRT_CXX_FLAGS "-fp-model ${FP_MODEL}")
+  list (APPEND PBRT_CXX_FLAGS "-fp-model" "${FP_MODEL}")
 endif ()
 
 if (MSVC AND MSVC_VERSION LESS 1920)
@@ -335,7 +335,7 @@ int main() {
 " HAVE_MMAP)
 
 if (HAVE_MMAP)
-  set(PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_HAVE_MMAP)
+  list (APPEND PBRT_DEFINITIONS "PBRT_HAVE_MMAP")
 ENDIF ()
 
 include (CheckIncludeFiles)
@@ -349,7 +349,7 @@ int main() {
 } " HAS_INTRIN_H)
 
 if (HAS_INTRIN_H)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_HAS_INTRIN_H)
+  list (APPEND PBRT_DEFINITIONS "PBRT_HAS_INTRIN_H")
 endif ()
 
 ########################################
@@ -366,11 +366,11 @@ int main() { }"
 HAVE_ATTRIBUTE_NOINLINE)
 
 if (HAVE_ATTRIBUTE_NOINLINE)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} "PBRT_NOINLINE=__attribute__((noinline))")
+  list (APPEND PBRT_DEFINITIONS "PBRT_NOINLINE=__attribute__((noinline))")
 elseif (HAVE_DECLSPEC_NOINLINE)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} "PBRT_NOINLINE=__declspec(noinline)")
+  list (APPEND PBRT_DEFINITIONS "PBRT_NOINLINE=__declspec(noinline)")
 else ()
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_NOINLINE)
+  list (APPEND PBRT_DEFINITIONS "PBRT_NOINLINE")
 endif ()
 
 ########################################
@@ -389,9 +389,9 @@ int main() {
 } " HAVE_POSIX_MEMALIGN )
 
 if (HAVE__ALIGNED_MALLOC)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_HAVE__ALIGNED_MALLOC)
+  list (APPEND PBRT_DEFINITIONS "PBRT_HAVE__ALIGNED_MALLOC")
 elseif (HAVE_POSIX_MEMALIGN)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_HAVE_POSIX_MEMALIGN)
+  list (APPEND PBRT_DEFINITIONS "PBRT_HAVE_POSIX_MEMALIGN")
 else ()
   message (SEND_ERROR "Unable to find a way to allocate aligned memory")
 endif ()
@@ -407,7 +407,7 @@ int main() { }
 " INT64_IS_OWN_TYPE)
 
 if (INT64_IS_OWN_TYPE)
-  set (PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PBRT_INT64_IS_OWN_TYPE)
+  list (APPEND PBRT_DEFINITIONS "PBRT_INT64_IS_OWN_TYPE")
 
 endif ()
 if (PBRT_NVTX)
@@ -647,7 +647,7 @@ endif ()
 ###########################################################################
 # pbrt libraries and executables
 
-set(PBRT_DEFINITIONS ${PBRT_DEFINITIONS} PTEX_STATIC)
+list (APPEND PBRT_DEFINITIONS "PTEX_STATIC")
 
 ######################
 # soac
@@ -749,15 +749,15 @@ if (PBRT_CUDA_ENABLED)
       ${PBRT_EMBEDDED_PTX}
       )
   add_dependencies (pbrt_embedded_ptx_lib pbrt_soa_generated)
-  set (ALL_PBRT_LIBS ${ALL_PBRT_LIBS} pbrt_embedded_ptx_lib)
+  list (APPEND ALL_PBRT_LIBS pbrt_embedded_ptx_lib)
 endif()
 
 if (WIN32)
-  set (ALL_PBRT_LIBS ${ALL_PBRT_LIBS} dbghelp wsock32 ws2_32)
+  list (APPEND ALL_PBRT_LIBS "dbghelp" "wsock32" "ws2_32")
 endif ()
 
 if (PROFILE_LIB)
-  set(ALL_PBRT_LIBS ${ALL_PBRT_LIBS} ${PROFILE_LIB})
+  list (APPEND ALL_PBRT_LIBS "${PROFILE_LIB}")
 endif ()
 
 ######################

--- a/src/pbrt/util/check.h
+++ b/src/pbrt/util/check.h
@@ -66,15 +66,22 @@ void PrintStackTrace();
 
 #else
 
-#define DCHECK(x)
-#define DCHECK_EQ(a, b)
-#define DCHECK_NE(a, b)
-#define DCHECK_GT(a, b)
-#define DCHECK_GE(a, b)
-#define DCHECK_LT(a, b)
-#define DCHECK_LE(a, b)
+#define EMPTY_CHECK \
+    do {            \
+    } while (false) /* swallow semicolon */
 
-#endif
+// Use an empty check (rather than expanding the macros to nothing) to swallow the
+// semicolon at the end, and avoid empty if-statements.
+#define DCHECK(x) EMPTY_CHECK
+
+#define DCHECK_EQ(a, b) EMPTY_CHECK
+#define DCHECK_NE(a, b) EMPTY_CHECK
+#define DCHECK_GT(a, b) EMPTY_CHECK
+#define DCHECK_GE(a, b) EMPTY_CHECK
+#define DCHECK_LT(a, b) EMPTY_CHECK
+#define DCHECK_LE(a, b) EMPTY_CHECK
+
+#endif  // !defined(NDEBUG)
 
 #define CHECK_RARE_TO_STRING(x) #x
 #define CHECK_RARE_EXPAND_AND_TO_STRING(x) CHECK_RARE_TO_STRING(x)


### PR DESCRIPTION
Various improvements to the CMake configuration, focused around replacing variables with interface libraries for collecting flags and definitions, as the latter allows generator expressions which can be used to only apply flags for certain compilers or languages.

Currently only the warning suppression flags are processed that way, allowing them to be used once again even when using the CUDA backend.