### PR TITLE
Fix compute capability calculation in cudacheck

### DIFF
--- a/cmake/checkcuda.cu
+++ b/cmake/checkcuda.cu
@@ -13,9 +13,10 @@ int main(int argc, char **argv){
         printf("CUDA error: %s\n", cudaGetErrorString(error));
         return rc; /* Failure */
     }
-    if((dP.major+(dP.minor/10)) < min_cc) {
-        printf("Minimum Compute Capability of %2.1f required: %d.%d found. Not Building CUDA Code.\n",
-               min_cc, dP.major, dP.minor);
+    float cc = dP.major + (dP.minor / 10.0);
+    if(cc < min_cc) {
+        printf("Minimum Compute Capability of %2.1f required: %2.1f found. Not Building CUDA Code.\n",
+               min_cc, cc);
         return 1; /* Failure */
     } else {
         printf("sm_%d%d", dP.major, dP.minor);


### PR DESCRIPTION
Small fix to cudacheck, the integer divide was rounding down the compute capability to just the major version. Probably didn't impact too many users unless they were running compute capability 5.3 devices.

Thank you for all your work on pbrt, really looking forward to the next edition of the book!