### PR TITLE
Fixes cmake policy CMP0077 build error on windows

### DIFF
--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -44,6 +44,9 @@ set (ZLIB_LIBRARIES ${ZLIB_LIBARIES} PARENT_SCOPE)
 
 ###########################################################################
 # OpenEXR
+if (POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
 
 set (ILMBASE_NAMESPACE_VERSIONING OFF CACHE BOOL " " FORCE)
 set (OPENEXR_NAMESPACE_VERSIONING OFF CACHE BOOL " " FORCE)


### PR DESCRIPTION
There is a cmake error when trying to build on Windows using cmake version 3.17.3. Running cmake generates the following error for ILMBASE:

> -- Configure ILMBASE Version: 2.5.3 Lib API: 25.0.2
> CMake Warning (dev) at src/ext/openexr/IlmBase/config/IlmBaseSetup.cmake:56 (option):
>   Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
>   --help-policy CMP0077" for policy details.  Use the cmake_policy command to
>   set the policy and suppress this warning.
> 
>   For compatibility with older versions of CMake, option is clearing the
>   normal variable 'BUILD_SHARED_LIBS'.
> Call Stack (most recent call first):
>   src/ext/openexr/IlmBase/CMakeLists.txt:35 (include)
> This warning is for project developers.  Use -Wno-dev to suppress it.

When trying to building the code in Visual Studio I get multiple errors along the lines of:

> Error C2491 'Imf_2_5::TypedAttribute<Imath_2_5::Box2i>::staticTypeName': definition of dllimport function not allowed

Setting the policy CMP007 in the CMakeLists.txt file before building OpenEXR seems to resolve the issue.