### PR TITLE
Apply CMake CMP0077 policy in a different way

### DIFF
--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -44,9 +44,8 @@ set (ZLIB_LIBRARIES ${ZLIB_LIBARIES} PARENT_SCOPE)
 
 ###########################################################################
 # OpenEXR
-if (POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
+
+SET (CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
 set (ILMBASE_NAMESPACE_VERSIONING OFF CACHE BOOL " " FORCE)
 set (OPENEXR_NAMESPACE_VERSIONING OFF CACHE BOOL " " FORCE)


### PR DESCRIPTION
I noticed on Ubuntu 20.04, CMake 3.16.3, and dc107ca the various IlmBase libraries were being compiled as shared instead of static.

This also syncs up with the comment from @povmaniaco here - https://github.com/mmp/pbrt-v4/pull/95#issuecomment-755226187

When building with CMake 3.16.3 or 3.19.2 I see this in output:
```
CMake Warning (dev) at src/ext/openexr/IlmBase/config/IlmBaseSetup.cmake:56 (option):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'BUILD_SHARED_LIBS'.
```

I came across these comments about policies being unset:
https://gitlab.kitware.com/cmake/cmake/-/issues/20312#note_692953  and https://gitlab.kitware.com/cmake/cmake/-/issues/20622
By setting `SET (CMAKE_POLICY_DEFAULT_CMP0077 NEW)` we can set a global policy default which "survives" when the cmake_minimum_required is called in the in the subdirectories.

This change results in static IlmBase libraries as desired.

It should be noted however according to the CMake docs,  https://cmake.org/cmake/help/v3.16/variable/CMAKE_POLICY_DEFAULT_CMPNNNN.html
> This variable should not be set by a project in CMake code; use cmake_policy(SET) instead.

So this seems somewhat counter to you are suppose to do according to the docs, but I'm not sure of an alternative solution.

