### PR TITLE
Use CMAKE_CUDA_COMPILER instead of nvcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,9 +193,15 @@ if (CMAKE_CUDA_COMPILER)
             # Get CUDA compute capability
             set (CHECK_CUDA_OUTPUT_EXE ${CMAKE_BINARY_DIR}/checkcuda)
             if (MSVC)
-                execute_process (COMMAND nvcc -lcuda ${CMAKE_SOURCE_DIR}/cmake/checkcuda.cu -ccbin ${CMAKE_CXX_COMPILER} -o ${CHECK_CUDA_OUTPUT_EXE})
+                execute_process (COMMAND ${CMAKE_CUDA_COMPILER} -lcuda ${CMAKE_SOURCE_DIR}/cmake/checkcuda.cu -ccbin ${CMAKE_CXX_COMPILER} -o ${CHECK_CUDA_OUTPUT_EXE}
+                                 RESULT_VARIABLE BUILD_CHECK_CUDA_RETURN_CODE)
             else  ()
-                execute_process (COMMAND nvcc -lcuda ${CMAKE_SOURCE_DIR}/cmake/checkcuda.cu -o ${CHECK_CUDA_OUTPUT_EXE})
+                execute_process (COMMAND ${CMAKE_CUDA_COMPILER} -lcuda ${CMAKE_SOURCE_DIR}/cmake/checkcuda.cu -o ${CHECK_CUDA_OUTPUT_EXE}
+                                 RESULT_VARIABLE BUILD_CHECK_CUDA_RETURN_CODE)
+            endif ()
+
+            if (NOT ${BUILD_CHECK_CUDA_RETURN_CODE} EQUAL 0)
+                message (SEND_ERROR "Was unable to build checkcuda, consider manually setting PBRT_GPU_SHADER_MODEL")
             endif ()
 
             execute_process (COMMAND ${CHECK_CUDA_OUTPUT_EXE}


### PR DESCRIPTION
When building `checkcuda` nvcc might not be on the $PATH, instead rely on the CMake variable CMAKE_CUDA_COMPILER which will be defined by this point in the CMakeLists.txt

This will fix the following cmake error
```
-- Found CUDA: /usr/local/cuda (found version "11.2") 
-- Found CUDA: 11.2
-- The CUDA compiler identification is NVIDIA 11.2.67
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: /usr/local/cuda-11.2/bin/nvcc - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
CMake Error at CMakeLists.txt:206 (message):
```

This error is due to the following failing
```
            execute_process (COMMAND ${CHECK_CUDA_OUTPUT_EXE}
                             RESULT_VARIABLE CUDA_RETURN_CODE
                             OUTPUT_VARIABLE CHECK_CUDA_OUTPUT)
```

As a result of `${CHECK_CUDA_OUTPUT_EXE}` not being previously built.
