### PR TITLE
imgtool, update info help along with adding makesky metadata

### DIFF
--- a/src/pbrt/cmd/imgtool.cpp
+++ b/src/pbrt/cmd/imgtool.cpp
@@ -191,6 +191,11 @@ static std::map<std::string, CommandUsage> commandUsage = {
     --ramp             Generate an image of the color ramp; <filename> is ignored
                        if specified.
 )")}},
+    {"info", {"info <filename>",
+              "Prints out image information including resolution, colorspace and pixel stats",
+              std::string(R"(
+    (No options)
+)")}},
     {"makeequiarea", {"makeequiarea [options] <filename>",
                       "Convert a equirectangular environment map (as used in pbrt-v3)\n"
                       "    to an equi-area parameterization (as used in pbrt-v4).",
@@ -381,6 +386,11 @@ int makesky(std::vector<std::string> args) {
 
     ImageMetadata metadata;
     metadata.colorSpace = colorSpace;
+    std::map<std::string, std::vector<std::string>> stringVectors;
+    stringVectors["makesky.albedo"] = { std::to_string(albedo) };
+    stringVectors["makesky.elevation"] = { std::to_string(elevation) };
+    stringVectors["makesky.turbidity"] = { std::to_string(turbidity) };
+    metadata.stringVectors = stringVectors;
     CHECK(img.Write(outfile, metadata));
 
     return 0;


### PR DESCRIPTION
Two small changes to imgtool

First change is to add the "info" option to the help.

For the second change, I keep forgetting to make a note of what makesky settings I used when creating a envmap. I figured the easiest solution is to record the parameter values in the image metadata.

`imgtool makesky --outfile blah.exr`

`imgtool info blah.exr `
```
blah.exr:
        resolution (2048, 2048)
        pixel format: Float
        color space : ACES
        full resolution (2048, 2048)
        pixel bounds (0, 0) - (2048, 2048)
        "makesky.albedo": [ "0.500000" ]
        "makesky.elevation": [ "0.174533" ]
        "makesky.turbidity": [ "3.000000" ]
        Channels:
                               B: min            0 max      5222.34 avg     0.057673 (0 infinite, 0 not-a-number)
                               G: min            0 max      10177.2 avg    0.0763236 (0 infinite, 0 not-a-number)
                               R: min            0 max      11672.2 avg    0.0812692 (0 infinite, 0 not-a-number)
```

While technically it's probably better to store the values as the actual data types, using ImageMetadata.stringVectors seemed the most straight forward approach without bloating the code.