### PR TITLE
Add support for reading gzip scene files

### DIFF
--- a/src/pbrt/parser.cpp
+++ b/src/pbrt/parser.cpp
@@ -137,6 +137,11 @@ std::unique_ptr<Tokenizer> Tokenizer::CreateFromFile(
         return std::make_unique<Tokenizer>(std::move(str), std::move(errorCallback));
     }
 
+    if (HasExtension(filename, ".gz")) {
+        std::string str = ReadDecompressedFileContents(filename);
+        return std::make_unique<Tokenizer>(std::move(str), std::move(errorCallback));
+    }
+
 #ifdef PBRT_HAVE_MMAP
     int fd = open(filename.c_str(), O_RDONLY);
     if (fd == -1) {
@@ -197,7 +202,7 @@ std::unique_ptr<Tokenizer> Tokenizer::CreateFromFile(
     return std::make_unique<Tokenizer>(ptr, len, filename, std::move(errorCallback));
 #else
     std::string str = ReadFileContents(filename);
-    return std::make_unique_ptr<Tokenizer>(std::move(str), std::move(errorCallback));
+    return std::make_unique<Tokenizer>(std::move(str), std::move(errorCallback));
 #endif
 }
 

--- a/src/pbrt/util/file.cpp
+++ b/src/pbrt/util/file.cpp
@@ -143,9 +143,19 @@ std::string ReadDecompressedFileContents(std::string filename) {
     do {
         bytesRead = gzread(f, buffer, 4096);
         contents.append(buffer, bytesRead);
-    } while ( !gzeof(f) );
+    } while ( !gzeof(f) || bytesRead < 0);
+   
+    int status = gzclose(f);
     
-    gzclose(f);
+    if (bytesRead < 0) {
+        Error("%s: zlib read error", filename);
+        return {};
+    }
+
+    if (status == Z_BUF_ERROR) {
+        Error("%s: incomplete file", filename);
+        return {};
+    }
 
     return contents;
 }

--- a/src/pbrt/util/file.cpp
+++ b/src/pbrt/util/file.cpp
@@ -8,6 +8,8 @@
 #include <pbrt/util/error.h>
 #include <pbrt/util/string.h>
 
+#include <zlib/zlib.h>
+
 #include <filesystem/path.h>
 #include <algorithm>
 #include <cctype>
@@ -124,6 +126,28 @@ std::string ReadFileContents(std::string filename) {
         ErrorExit("%s: %s", filename, ErrorString());
     return std::string((std::istreambuf_iterator<char>(ifs)),
                        (std::istreambuf_iterator<char>()));
+}
+
+std::string ReadDecompressedFileContents(std::string filename) {
+
+    std::string contents;
+
+    gzFile f = gzopen(filename.c_str(), "rb");
+    if (!f) {
+        Error("%s: unable to open file", filename);
+        return {};
+    }
+    
+    char buffer[4096];
+    int bytesRead = 0;
+    do {
+        bytesRead = gzread(f, buffer, 4096);
+        contents.append(buffer, bytesRead);
+    } while ( !gzeof(f) );
+    
+    gzclose(f);
+
+    return contents;
 }
 
 FILE *FOpenRead(std::string filename) {

--- a/src/pbrt/util/file.h
+++ b/src/pbrt/util/file.h
@@ -15,6 +15,7 @@
 namespace pbrt {
 
 // File and Filename Function Declarations
+std::string ReadDecompressedFileContents(std::string filename);
 std::string ReadFileContents(std::string filename);
 bool WriteFileContents(std::string filename, const std::string &contents);
 


### PR DESCRIPTION
This PR adds support for reading gzipped scene files, directly or through Include or Import statements.

The main motivator was dealing with very large uniformgrid volumes. As a contrived example, a scene file with a 512^3 voxel array with values of 1 results in a 257MB file. But compressed it is only 256KB.

As a bonus pbrt-v4 already has zlib as an external resource so this change doesn't add a new dependency.

Lastly, through gzerror(...) better error messages can be generated to help relay causes of errors, however in an attempt to keep the code reasonably straight forward I omitted all but the most basic error conditions.

This was tested on Linux and Windows.