### PR TITLE
Fix scaling of u when sampling infinite lights

### DIFF
--- a/src/pbrt/lightsamplers.cpp
+++ b/src/pbrt/lightsamplers.cpp
@@ -269,7 +269,7 @@ pstd::optional<SampledLight> ExhaustiveLightSampler::Sample(const LightSampleCon
 
     // Note: shared with BVH light sampler...
     if (u < pInfinite) {
-        u = std::min<Float>(u * pInfinite, OneMinusEpsilon);
+        u /= pInfinite;
         int index = std::min<int>(u * infiniteLights.size(), infiniteLights.size() - 1);
         Float pdf = pInfinite * 1.f / infiniteLights.size();
         return SampledLight{infiniteLights[index], pdf};

--- a/src/pbrt/lightsamplers.h
+++ b/src/pbrt/lightsamplers.h
@@ -275,7 +275,7 @@ class BVHLightSampler {
 
         if (u < pInfinite) {
             // Sample infinite lights with uniform probability
-			u /= pInfinite;
+            u /= pInfinite;
             int index =
                 std::min<int>(u * infiniteLights.size(), infiniteLights.size() - 1);
             Float pdf = pInfinite / infiniteLights.size();

--- a/src/pbrt/lightsamplers.h
+++ b/src/pbrt/lightsamplers.h
@@ -275,7 +275,7 @@ class BVHLightSampler {
 
         if (u < pInfinite) {
             // Sample infinite lights with uniform probability
-            u *= pInfinite;
+			u /= pInfinite;
             int index =
                 std::min<int>(u * infiniteLights.size(), infiniteLights.size() - 1);
             Float pdf = pInfinite / infiniteLights.size();


### PR DESCRIPTION
Howdy,

# Overview

I noticed when rendering with at least one non-infinite light and multiple infinite lights that some of the infinite lights were not being sampled.

I believe this has to do with how `u` is being scaled. Instead of multiplying `u` by `pInfinite` we should be dividing so that `u` is between 0 and 1.

https://github.com/mmp/pbrt-v4/blob/43ce733ea0775a71045c7ccfada4d855901f2230/src/pbrt/lightsamplers.h#L273-L282

This affects the Path and VolPath integrators when using the BVH or Exhaustive light sampling strategies. 

# Example Scene
```
Film "rgb"
    "string filename" [ "light_bug.exr" ]
    "integer yresolution" [ 256 ]
    "integer xresolution" [ 256 ]
PixelFilter "gaussian"
    "float xradius" [ 2 ]
    "float yradius" [ 2 ]
Sampler "zsobol"
    "integer pixelsamples" [ 128 ]
Integrator "volpath"
    "integer maxdepth" [ 5 ]
	"string lightsampler" [ "bvh" ]
Accelerator "bvh"
Translate 0 1 7
Camera "perspective"
    "float screenwindow" [ -1 1 -1 1 ]
    "float fov" [ 45 ]


WorldBegin


AttributeBegin
    Translate 0 -3 0
    AreaLightSource "diffuse"
        "float scale" [ 20 ]
    Shape "sphere"
        "float radius" [ 0.2 ]
AttributeEnd

AttributeBegin
    Rotate 90 0 1 0
    LightSource "distant"
        "rgb L" [ 0 0 1 ]
        "float scale" [ 4 ]
AttributeEnd

AttributeBegin
    Rotate -90 0 1 0
    LightSource "distant"
        "rgb L" [ 1 0 0 ]
        "float scale" [ 4 ]
AttributeEnd

AttributeBegin
    Shape "sphere"
AttributeEnd
```
## master
![master](https://user-images.githubusercontent.com/2104033/128620008-d3570412-a4b8-49ed-9be1-69521b4f5c93.png)

##  infinite_light_fix  branch (This PR applied)
![infinite_light_fix](https://user-images.githubusercontent.com/2104033/128620018-abd42f12-cf7d-4669-9311-b74a0a2298d9.png)

# Note
For the ExhaustiveLightSampler fix, I replaced
`u = std::min<Float>(u * pInfinite, OneMinusEpsilon);`
with 
`u /= pInfinite;`

I don't think the min() against OneMinusEpsilon is needed because in the event that `u` is 1, the min() on the following line when computing the `index` handles that scenario.