### PR TITLE
Fixes to PBRT_DBG_LOGGING

### DIFF
--- a/src/pbrt/gpu/optix.cu
+++ b/src/pbrt/gpu/optix.cu
@@ -488,8 +488,8 @@ extern "C" __global__ void __raygen__randomHit() {
 
     uint32_t ptr0 = packPointer0(&payload), ptr1 = packPointer1(&payload);
 
-    PBRT_DBG("Randomhit raygen ray.o %f %f %f ray.d %f %f %f tMax %f\n", ray.o.x, ray.o.y,
-        ray.o.z, ray.d.x, ray.d.y, ray.d.z, tMax);
+    PBRT_DBG("Randomhit raygen ray.o %f %f %f ray.d %f %f %f\n", ray.o.x, ray.o.y,
+        ray.o.z, ray.d.x, ray.d.y, ray.d.z);
 
     while (true) {
         Trace(params.traversable, ray, 0.f /* tMin */, 1.f /* tMax */,

--- a/src/pbrt/wavefront/intersect.h
+++ b/src/pbrt/wavefront/intersect.h
@@ -245,8 +245,8 @@ inline PBRT_CPU_GPU void TraceTransmittance(ShadowRayWorkItem sr,
                     PBRT_DBG(
                         "T_maj %f %f %f %f sigma_n %f %f %f %f sigma_maj %f %f %f %f\n",
                         T_maj[0], T_maj[1], T_maj[2], T_maj[3], sigma_n[0], sigma_n[1],
-                        sigma_n[2], sigma_n[3], intr.sigma_maj[0], intr.sigma_maj[1],
-                        intr.sigma_maj[2], intr.sigma_maj[3]);
+                        sigma_n[2], sigma_n[3], sigma_maj[0], sigma_maj[1], sigma_maj[2],
+                        sigma_maj[3]);
                     PBRT_DBG("T_ray %f %f %f %f lightPathPDF %f %f %f %f uniPathPDF %f "
                              "%f %f %f\n",
                              T_ray[0], T_ray[1], T_ray[2], T_ray[3], lightPathPDF[0],


### PR DESCRIPTION
Two small fixes to the debug printing. Some variables were removed or renamed in 59b5988 and 24c6ef5 and the debug prints got out of sync.