### PR TITLE
Updated links in readme for blender exporter.

### DIFF
--- a/exporters/Blender/Readme.md
+++ b/exporters/Blender/Readme.md
@@ -1,8 +1,8 @@
-Exporter for blender can be found here:
-https://github.com/stig-atle/io_scene_pbrt
+Pbrt-v4 exporter for blender can be found here:
+https://github.com/stig-atle/io_scene_pbrt/tree/Pbrt-v4-support
 
-Either clone the repository and place it in the blender addon folder,
+Either clone the Pbrt-v4-support branch and place it in the blender addon folder,
 or download as zip and install through the addon menu from the following url:
-https://github.com/stig-atle/pbrt-v4/archive/master.zip
+https://github.com/stig-atle/io_scene_pbrt/archive/refs/heads/Pbrt-v4-support.zip
 
 For more information about the exporter and how to use it - visit the repository.


### PR DESCRIPTION
The link in the readme that points to the addon zip archive was wrong.
I updated this and also point directly to the Pbrt-v4 branch so that it's less confusing for the users.