### PR TITLE
Use max instead of adding sigma values in UniformGridMediumProvider::maxDensityGrid()

### DIFF
--- a/src/pbrt/media.h
+++ b/src/pbrt/media.h
@@ -408,7 +408,7 @@ class UniformGridMediumProvider {
                         maxGrid[offset++] = densityGrid->MaxValue(bounds);
                     else if (sigma_aGrid)
                         maxGrid[offset++] =
-                            sigma_aGrid->MaxValue(bounds) + sigma_sGrid->MaxValue(bounds);
+                            std::max<Float>(sigma_aGrid->MaxValue(bounds), sigma_sGrid->MaxValue(bounds));
                     else {
                         auto max = [] PBRT_CPU_GPU(RGBUnboundedSpectrum s) {
                             return s.MaxValue();


### PR DESCRIPTION
I noticed a discrepancy between how `density` and `density.sigma_a|s` values are handled in `UniformGridMediumProvider::maxDensityGrid()`.

# Background

The max density for a medium using `density` or `density.rgb` simply takes the maximum of the density value
https://github.com/mmp/pbrt-v4/blob/11ef9b3d23e263d7b8f88277fd13e25d6cde0890/src/pbrt/media.h#L407-L408
https://github.com/mmp/pbrt-v4/blob/11ef9b3d23e263d7b8f88277fd13e25d6cde0890/src/pbrt/media.h#L413-L416

But if the user supplies `density.sigma_a` and `density.sigma_s` then those values are added together to compute the max density
https://github.com/mmp/pbrt-v4/blob/11ef9b3d23e263d7b8f88277fd13e25d6cde0890/src/pbrt/media.h#L409-L411

To be inline with how the max density is calculated by `density` or `density.rgb` I believe we should be using-
```
maxGrid[offset++] = std::max<Float>(sigma_aGrid->MaxValue(bounds), sigma_sGrid->MaxValue(bounds));
```

# Testing
When rendering the following 
```
    MakeNamedMedium "grid" "string type" "uniformgrid" 
        "float density.sigma_a" [ 10 10 10 10 10 10 10 10 ]
        "float density.sigma_s" [ 10 10 10 10 10 10 10 10 ]
        "integer nx" [ 2 ] "integer ny" [ 2 ] "integer nz" [ 2 ]
        "point3 p0" [ -1 -1 -1 ] "point3 p1" [ 1 1 1 ]
        "float scale" [ 1 ]
```
vs
```
    MakeNamedMedium "grid" "string type" "uniformgrid" 
        "float density" [ 10 10 10 10 10 10 10 10 ]
        "integer nx" [ 2 ] "integer ny" [ 2 ] "integer nz" [ 2 ]
        "point3 p0" [ -1 -1 -1 ] "point3 p1" [ 1 1 1 ]
        "float scale" [ 1 ]
```
You get slightly different results -
```
Images differ:
        sigma_master.exr density_master.exr
        avg = 0.34074637 / 0.34074596 (0.0001224468% delta), MSE = 3.745316e-7
```

However after applying this change a render using density or sigma values will match.
