### PR TITLE
Implementation to Provide RGB Grid Values for sigma_a and sigma_s

### DIFF
--- a/src/pbrt/base/medium.h
+++ b/src/pbrt/base/medium.h
@@ -45,9 +45,13 @@ class PhaseFunction : public TaggedPointer<HGPhaseFunction> {
 class HomogeneousMedium;
 template <typename Provider>
 class CuboidMedium;
-class UniformGridMediumProvider;
-// UniformGridMedium Definition
-using UniformGridMedium = CuboidMedium<UniformGridMediumProvider>;
+class GridMediumProvider;
+// GridMedium Definition
+using GridMedium = CuboidMedium<GridMediumProvider>;
+
+class RGBGridMediumProvider;
+// RGBGridMedium Definition
+using RGBGridMedium = CuboidMedium<RGBGridMediumProvider>;
 
 class CloudMediumProvider;
 // CloudMedium Definition
@@ -92,7 +96,7 @@ class RayMajorantIterator
 };
 
 // Medium Definition
-class Medium : public TaggedPointer<HomogeneousMedium, UniformGridMedium, CloudMedium,
+class Medium : public TaggedPointer<HomogeneousMedium, GridMedium, RGBGridMedium, CloudMedium,
                                     NanoVDBMedium> {
   public:
     // Medium Interface

--- a/src/pbrt/media.cpp
+++ b/src/pbrt/media.cpp
@@ -272,81 +272,40 @@ UniformGridMediumProvider *UniformGridMediumProvider::Create(
     std::vector<RGB> rgbSigma_s = parameters.GetRGBArray("density.sigma_s.rgb");
 
     size_t nDensity;
-    if (!density.empty()) {
+    if (!density.empty() && rgbDensity.empty() && sigma_a.empty() && sigma_s.empty() &&
+            rgbSigma_a.empty() && rgbSigma_s.empty())
         nDensity = density.size();
-        if (!sigma_a.empty())
-            ErrorExit(loc,
-                      "Both \"density\" and \"density.sigma_a\" values were provided.");
-        if (!sigma_s.empty())
-            ErrorExit(loc,
-                      "Both \"density\" and \"density.sigma_s\" values were provided.");
-        if (!rgbDensity.empty())
-            ErrorExit(loc, "Both \"density\" and \"density.rgb\" values were provided.");
-        if (!rgbSigma_a.empty())
-            ErrorExit(loc,
-                      "Both \"density\" and \"density.sigma_a.rgb\" values were provided.");
-        if (!rgbSigma_s.empty())
-            ErrorExit(loc,
-                      "Both \"density\" and \"density.sigma_s.rgb\" values were provided.");
-    } else if (!rgbDensity.empty()) {
+    else if (!rgbDensity.empty() && density.empty() && sigma_a.empty() &&
+             sigma_s.empty() && rgbSigma_a.empty() && rgbSigma_s.empty())
         nDensity = rgbDensity.size();
-        if (!sigma_a.empty())
+    else if ((!sigma_a.empty() ^ !rgbSigma_a.empty()) && 
+             (!sigma_s.empty() ^ !rgbSigma_s.empty()) && density.empty() &&
+             rgbDensity.empty()) {
+        size_t aSize = !sigma_a.empty() ? sigma_a.size() : rgbSigma_a.size();
+        size_t sSize = !sigma_s.empty() ? sigma_s.size() : rgbSigma_s.size();
+        if ( aSize != sSize)
             ErrorExit(loc,
-                      "Both \"density.rgb\" and \"density.sigma_a\" values were provided.");
-        if (!sigma_s.empty())
-            ErrorExit(loc,
-                      "Both \"density.rgb\" and \"density.sigma_s\" values were provided.");
-        if (!rgbSigma_a.empty())
-            ErrorExit(loc,
-                      "Both \"density.rgb\" and \"density.sigma_a.rgb\" values were provided.");
-        if (!rgbSigma_s.empty())
-            ErrorExit(loc,
-                      "Both \"density.rgb\" and \"density.sigma_s.rgb\" values were provided.");
-    } else if (!sigma_a.empty()) {
-        if (!rgbSigma_a.empty())
-            ErrorExit(loc,
-                      "Both \"density.sigma_a\" and \"density.sigma_a.rgb\" values were provided.");
-        nDensity = sigma_a.size();
-        if (!sigma_s.empty()) {
-            if (!rgbSigma_s.empty())
-                ErrorExit(loc,
-                          "Both \"density.sigma_s\" and \"density.sigma_s.rgb\" values were provided.");
-            if (sigma_s.size() != sigma_a.size())
-                ErrorExit(loc,
-                          "Different number of samples (%d vs %d) provided for "
-                          "\"density.sigma_a\" and \"density.sigma_s\".",
-                          sigma_a.size(), sigma_s.size());
-        } else if (!rgbSigma_s.empty()) {
-            if (rgbSigma_s.size() != sigma_a.size())
-                ErrorExit(loc,
-                          "Different number of samples (%d vs %d) provided for "
-                          "\"density.sigma_a\" and \"density.sigma_s.rgb\".",
-                          sigma_a.size(), rgbSigma_s.size());
-        } else
-            ErrorExit(loc, "No \"density.sigma_s\" or \"density.sigma_s.rgb\" provided with \"sigma_a\".");
-    } else if (!rgbSigma_a.empty()) {
-        nDensity = rgbSigma_a.size();
-        if (!sigma_s.empty()) {
-            if (!rgbSigma_s.empty())
-                ErrorExit(loc,
-                          "Both \"density.sigma_s\" and \"density.sigma_s.rgb\" values were provided.");
-            if (sigma_s.size() != rgbSigma_a.size())
-                ErrorExit(loc,
-                          "Different number of samples (%d vs %d) provided for "
-                          "\"density.sigma_a.rgb\" and \"density.sigma_s\".",
-                          rgbSigma_a.size(), sigma_s.size());
-        } else if (!rgbSigma_s.empty()) {
-            if (rgbSigma_s.size() != rgbSigma_a.size())
-                ErrorExit(loc,
-                          "Different number of samples (%d vs %d) provided for "
-                          "\"density.sigma_a.rgb\" and \"density.sigma_s.rgb\".",
-                          rgbSigma_a.size(), rgbSigma_s.size());
-        } else
-            ErrorExit(loc, "No \"density.sigma_s/density.sigma_s.rgb\" provided with \"density.sigma_a.rgb\".");
-    }  else if (!sigma_s.empty() || !rgbSigma_s.empty())
-        ErrorExit(loc, "No \"density.sigma_a/density.sigma_a.rgb\" provided with \"density.sigma_s/density.sigma_s.rgb\".");
-    else
-        ErrorExit(loc, "No \"density\" values provided for uniform grid medium.");
+                      "Different number of samples (%d vs %d) provided for "
+                      "\"density.sigma_a[.rgb]\" and \"density.sigma_s[.rgb]\".",
+                      aSize, sSize);
+        nDensity = aSize;
+    } else
+        ErrorExit(loc, "Invalid density parameters provided for uniform grid medium. "
+                        "Supported parameters combinations are one of:\n"
+                        "    \"density\"\n"
+                        "    \"density.rgb\"\n"
+                        "    \"density.sigma_a\" and \"density.sigma_s\"\n"
+                        "    \"density.sigma_a.rgb\" and \"density.sigma_\"s\n"
+                        "    \"density.sigma_a\" and \"density.sigma_s.rgb\"\n"
+                        "    \"density.sigma_a.rgb\" and \"density.sigma_s.rgb\"\n"
+                        "  Parameters provided:\n"
+                        "%s%s%s%s%s%s", 
+                        !density.empty() ? "    \"density\"\n" : "",
+                        !rgbDensity.empty() ? "    \"density.rgb\"\n" : "",
+                        !sigma_a.empty() ? "    \"density.sigma_a\"\n" : "",
+                        !sigma_s.empty() ? "    \"density.sigma_s\"\n" : "",
+                        !rgbSigma_a.empty() ? "    \"density.sigma_a.rgb\"\n" : "",
+                        !rgbSigma_s.empty() ? "    \"density.sigma_s.rgb\"\n" : "");
 
     int nx = parameters.GetOneInt("nx", 1);
     int ny = parameters.GetOneInt("ny", 1);

--- a/src/pbrt/media.cpp
+++ b/src/pbrt/media.cpp
@@ -295,7 +295,7 @@ UniformGridMediumProvider *UniformGridMediumProvider::Create(
                         "    \"density\"\n"
                         "    \"density.rgb\"\n"
                         "    \"density.sigma_a\" and \"density.sigma_s\"\n"
-                        "    \"density.sigma_a.rgb\" and \"density.sigma_\"s\n"
+                        "    \"density.sigma_a.rgb\" and \"density.sigma_s\"\n"
                         "    \"density.sigma_a\" and \"density.sigma_s.rgb\"\n"
                         "    \"density.sigma_a.rgb\" and \"density.sigma_s.rgb\"\n"
                         "  Parameters provided:\n"

--- a/src/pbrt/media.h
+++ b/src/pbrt/media.h
@@ -463,12 +463,12 @@ class RGBGridMediumProvider {
         if (sigma_aGrid)
             a = sigma_aGrid->Lookup(pp, convert);
         else
-            a = SampledSpectrum(0.f);
+            a = SampledSpectrum(1.f);
 
         if (sigma_sGrid)
             s = sigma_sGrid->Lookup(pp, convert);
         else
-            s = SampledSpectrum(0.f);
+            s = SampledSpectrum(1.f);
 
         return MediumDensity(a, s);
     }

--- a/src/pbrt/media.h
+++ b/src/pbrt/media.h
@@ -419,7 +419,6 @@ class UniformGridMediumProvider {
                         maxGrid[offset++] = densityGrid->MaxValue(bounds);
                     else if (sigma_aGrid && sigma_sGrid)
                         maxGrid[offset++] =
-                            //sigma_aGrid->MaxValue(bounds) + sigma_sGrid->MaxValue(bounds);
                             std::max<Float>(sigma_aGrid->MaxValue(bounds) , sigma_sGrid->MaxValue(bounds));
                     else {
                         auto max = [] PBRT_CPU_GPU(RGBUnboundedSpectrum s) {
@@ -428,15 +427,16 @@ class UniformGridMediumProvider {
                         if (rgbGrid) {
                             maxGrid[offset] = rgbGrid->MaxValue(bounds, max);
                         } else {
-                            maxGrid[offset] = 0.0;
+                            Float gridMax = 0.0;
                             if (sigma_aGrid)
-                                maxGrid[offset] += sigma_aGrid->MaxValue(bounds);
+                                gridMax = std::max<Float>(sigma_aGrid->MaxValue(bounds), gridMax);
                             if (rgbSigma_aGrid)
-                                maxGrid[offset] += rgbSigma_aGrid->MaxValue(bounds, max);
+                                gridMax = std::max<Float>(rgbSigma_aGrid->MaxValue(bounds, max), gridMax);
                             if (sigma_sGrid)
-                                maxGrid[offset] += sigma_sGrid->MaxValue(bounds);
+                                gridMax = std::max<Float>(sigma_sGrid->MaxValue(bounds), gridMax);
                             if (rgbSigma_sGrid)
-                                maxGrid[offset] += rgbSigma_sGrid->MaxValue(bounds, max);
+                                gridMax = std::max<Float>(rgbSigma_sGrid->MaxValue(bounds, max), gridMax);
+                            maxGrid[offset] = gridMax;
                         }
                         offset++;
                     }

--- a/src/pbrt/media.h
+++ b/src/pbrt/media.h
@@ -346,21 +346,17 @@ class CuboidMedium {
     Point3i gridResolution;
 };
 
-// UniformGridMediumProvider Definition
-class UniformGridMediumProvider {
-  public:
-    // UniformGridMediumProvider Public Methods
-    UniformGridMediumProvider(const Bounds3f &bounds,
-                              pstd::optional<SampledGrid<Float>> density,
-                              pstd::optional<SampledGrid<Float>> sigma_a,
-                              pstd::optional<SampledGrid<Float>> sigma_s,
-                              pstd::optional<SampledGrid<RGBUnboundedSpectrum>> rgb,
-                              pstd::optional<SampledGrid<RGBUnboundedSpectrum>> rgbSigma_a,
-                              pstd::optional<SampledGrid<RGBUnboundedSpectrum>> rgbSigma_s,
-                              Spectrum Le, SampledGrid<Float> LeScale, Allocator alloc);
 
-    static UniformGridMediumProvider *Create(const ParameterDictionary &parameters,
-                                             const FileLoc *loc, Allocator alloc);
+// GridMediumProvider Definition
+class GridMediumProvider {
+  public:
+    // GridMediumProvider Public Methods
+    GridMediumProvider(const Bounds3f &bounds, SampledGrid<Float> density,
+                       pstd::optional<SampledGrid<Float>> temperature, Spectrum Le,
+                       SampledGrid<Float> LeScale, Allocator alloc);
+
+    static GridMediumProvider *Create(const ParameterDictionary &parameters,
+                                      const FileLoc *loc, Allocator alloc);
 
     std::string ToString() const;
 
@@ -368,39 +364,29 @@ class UniformGridMediumProvider {
     const Bounds3f &Bounds() const { return bounds; }
 
     PBRT_CPU_GPU
-    bool IsEmissive() const { return Le_spec.MaxValue() > 0; }
+    bool IsEmissive() const {
+        if (temperatureGrid)
+            // TODO Assume the grid's max value is greater than 100.f?
+            return true;
+        return Le_spec.MaxValue() > 0;
+    }
 
     PBRT_CPU_GPU
     SampledSpectrum Le(Point3f p, const SampledWavelengths &lambda) const {
         Point3f pp = Point3f(bounds.Offset(p));
+        if (temperatureGrid) {
+            Float temp = temperatureGrid->Lookup(pp);
+            if (temp <= 100.f)
+                return SampledSpectrum(0.f);
+            return LeScale.Lookup(pp) * BlackbodySpectrum(temp).Sample(lambda);
+        }
         return Le_spec.Sample(lambda) * LeScale.Lookup(pp);
     }
 
     PBRT_CPU_GPU
     MediumDensity Density(Point3f p, const SampledWavelengths &lambda) const {
         Point3f pp = Point3f(bounds.Offset(p));
-        if (densityGrid)
-            return MediumDensity(densityGrid->Lookup(pp));
-        else {
-            // Return _SampledSpectrum_ density from _rgb_
-            auto convert = [=] PBRT_CPU_GPU(RGBUnboundedSpectrum s) {
-                return s.Sample(lambda);
-            };
-            SampledSpectrum a, s;
-            if (sigma_aGrid)
-                a = SampledSpectrum(sigma_aGrid->Lookup(pp));
-            if (rgbSigma_aGrid)
-                a = rgbSigma_aGrid->Lookup(pp, convert);
-            if (sigma_sGrid)
-                s = SampledSpectrum(sigma_sGrid->Lookup(pp));
-            if (rgbSigma_sGrid)
-                s = rgbSigma_sGrid->Lookup(pp, convert);
-            if (rgbGrid) {
-                a = rgbGrid->Lookup(pp, convert);
-                s = a;
-            }
-            return MediumDensity(a, s);
-        }
+        return MediumDensity(densityGrid.Lookup(pp));
     }
 
     pstd::vector<Float> GetMaxDensityGrid(Allocator alloc, Point3i *res) const {
@@ -415,45 +401,111 @@ class UniformGridMediumProvider {
                         Point3f(x / res->x, y / res->y, z / res->z),
                         Point3f((x + 1) / res->x, (y + 1) / res->y, (z + 1) / res->z));
                     // Set current _maxGrid_ entry for maximum density over _bounds_
-                    if (densityGrid)
-                        maxGrid[offset++] = densityGrid->MaxValue(bounds);
-                    else if (sigma_aGrid && sigma_sGrid)
-                        maxGrid[offset++] =
-                            std::max<Float>(sigma_aGrid->MaxValue(bounds) , sigma_sGrid->MaxValue(bounds));
-                    else {
-                        auto max = [] PBRT_CPU_GPU(RGBUnboundedSpectrum s) {
-                            return s.MaxValue();
-                        };
-                        if (rgbGrid) {
-                            maxGrid[offset] = rgbGrid->MaxValue(bounds, max);
-                        } else {
-                            Float gridMax = 0.0;
-                            if (sigma_aGrid)
-                                gridMax = std::max<Float>(sigma_aGrid->MaxValue(bounds), gridMax);
-                            if (rgbSigma_aGrid)
-                                gridMax = std::max<Float>(rgbSigma_aGrid->MaxValue(bounds, max), gridMax);
-                            if (sigma_sGrid)
-                                gridMax = std::max<Float>(sigma_sGrid->MaxValue(bounds), gridMax);
-                            if (rgbSigma_sGrid)
-                                gridMax = std::max<Float>(rgbSigma_sGrid->MaxValue(bounds, max), gridMax);
-                            maxGrid[offset] = gridMax;
-                        }
-                        offset++;
-                    }
+                    maxGrid[offset++] = densityGrid.MaxValue(bounds);
                 }
-
         return maxGrid;
     }
 
   private:
-    // UniformGridMediumProvider Private Members
+    // GridMediumProvider Private Members
     Bounds3f bounds;
-    pstd::optional<SampledGrid<Float>> densityGrid;
-    pstd::optional<SampledGrid<Float>> sigma_aGrid, sigma_sGrid;
-    pstd::optional<SampledGrid<RGBUnboundedSpectrum>> rgbGrid;
-    pstd::optional<SampledGrid<RGBUnboundedSpectrum>> rgbSigma_aGrid, rgbSigma_sGrid;
+    SampledGrid<Float> densityGrid;
+    pstd::optional<SampledGrid<Float>> temperatureGrid;
     DenselySampledSpectrum Le_spec;
     SampledGrid<Float> LeScale;
+};
+
+// RGBGridMediumProvider Definition
+class RGBGridMediumProvider {
+  public:
+    // RGBGridMediumProvider Public Methods
+    RGBGridMediumProvider(const Bounds3f &bounds,
+                          pstd::optional<SampledGrid<RGBUnboundedSpectrum>> sigma_a,
+                          pstd::optional<SampledGrid<RGBUnboundedSpectrum>> sigma_s,
+                          pstd::optional<SampledGrid<RGBUnboundedSpectrum>> Le,
+                          Float LeScale, Allocator alloc);
+
+    static RGBGridMediumProvider *Create(const ParameterDictionary &parameters,
+                                         const FileLoc *loc, Allocator alloc);
+
+    std::string ToString() const;
+
+    PBRT_CPU_GPU
+    const Bounds3f &Bounds() const { return bounds; }
+
+    PBRT_CPU_GPU
+    bool IsEmissive() const {
+        if (LeGrid && LeScale > 0.0f)
+            return true;
+        return false;
+    }
+
+    PBRT_CPU_GPU
+    SampledSpectrum Le(Point3f p, const SampledWavelengths &lambda) const {
+        if (!LeGrid)
+            return SampledSpectrum(0.f);
+
+        Point3f pp = Point3f(bounds.Offset(p));
+        auto convert = [=] PBRT_CPU_GPU(RGBUnboundedSpectrum s) {
+            return s.Sample(lambda);
+        };
+        return LeScale * LeGrid->Lookup(pp, convert);
+    }
+
+    PBRT_CPU_GPU
+    MediumDensity Density(Point3f p, const SampledWavelengths &lambda) const {
+        Point3f pp = Point3f(bounds.Offset(p));
+        auto convert = [=] PBRT_CPU_GPU(RGBUnboundedSpectrum s) {
+            return s.Sample(lambda);
+        };
+
+        SampledSpectrum a, s;
+        if (sigma_aGrid)
+            a = sigma_aGrid->Lookup(pp, convert);
+        else
+            a = SampledSpectrum(0.f);
+
+        if (sigma_sGrid)
+            s = sigma_sGrid->Lookup(pp, convert);
+        else
+            s = SampledSpectrum(0.f);
+
+        return MediumDensity(a, s);
+    }
+
+    pstd::vector<Float> GetMaxDensityGrid(Allocator alloc, Point3i *res) const {
+        *res = Point3i(16, 16, 16);
+        pstd::vector<Float> maxGrid(res->x * res->y * res->z, Float(0), alloc);
+        // Compute maximum density for each _maxGrid_ cell
+        int offset = 0;
+        for (Float z = 0; z < res->z; ++z)
+            for (Float y = 0; y < res->y; ++y)
+                for (Float x = 0; x < res->x; ++x) {
+                    Bounds3f bounds(
+                        Point3f(x / res->x, y / res->y, z / res->z),
+                        Point3f((x + 1) / res->x, (y + 1) / res->y, (z + 1) / res->z));
+
+                    auto max = [] PBRT_CPU_GPU(RGBUnboundedSpectrum s) {
+                        return s.MaxValue();
+                    };
+
+                    Float gridMax = 0.0;
+                    if (sigma_aGrid)
+                        gridMax = std::max<Float>(sigma_aGrid->MaxValue(bounds, max),
+                                                  gridMax);
+                    if (sigma_sGrid)
+                        gridMax = std::max<Float>(sigma_sGrid->MaxValue(bounds, max),
+                                                  gridMax);
+                    maxGrid[offset++] = gridMax;
+                }
+        return maxGrid;
+    }
+
+  private:
+    // RGBGridMediumProvider Private Members
+    Bounds3f bounds;
+    pstd::optional<SampledGrid<RGBUnboundedSpectrum>> sigma_aGrid, sigma_sGrid, LeGrid;
+    Float LeScale;
 };
 
 // CloudMediumProvider Definition


### PR DESCRIPTION
_**Note**: The is PR is a Draft of an implementation, if the idea makes sense for pbrt-v4 (especially at this late stage) then I'm happy to tidy up the code, otherwise we can reject it._

# Problem Overview

Uniform Grid's `rgb density.rgb` option is a difficult interface for specifying coloured volumetrics. This is due to rgb values being used both for sigma_a and sigma_s.
https://github.com/mmp/pbrt-v4/blob/77d367204ad7c73eb5072c62f5e6f12604f0574d/src/pbrt/media.h#L386-L391

An rgb density value of (1,0,0) means you'll be scattering and absorbing red light in the cross section. The absorption of the red light results in a cyan being transmitted.

### Examples
The following are some renders of a density.rgb  setup, where the rgb values of each smoke plume start at red on the left and go purple on the right. In other words, the left most plume is red, the one next to it orange, etc.

#### Example 1: 
- sigma_a = {1,1,1};
- sigma_s = {1,1,1};
![rainbow_density_rgb](https://user-images.githubusercontent.com/2104033/135335695-0084402a-1092-4754-8b41-22862af3495a.png)

#### Example 2: 
- sigma_a = {0,0,0};
- sigma_s = {1,1,1};
![rainbow_density_rgb_a0](https://user-images.githubusercontent.com/2104033/135349739-c14d40c2-3f77-40fb-9944-f2e0825dcb80.png)


- #### Example 3: 
- sigma_a = {1,1,1};
- sigma_s = {0,0,0};
![rainbow_density_rgb_s0](https://user-images.githubusercontent.com/2104033/135350032-a7b0c580-0dc0-4de3-b919-82b48a4a6d02.png)


# PR Changes
### Allow for "rgb" versions of sigma_a and sigma_s
Here we add two new parameters `rgb density.sigma_a.rgb` and `rgb density.sigma_s.rgb`. This gives us independent color controls over for our sigma values.

Additionally the user has the option to supply a float or rgb version of sigma_a / sigma_s.

#### Example: 
Using the same example as before but instead of specifying `density.rgb` we use `density.sigma_a.rgb` and `density.sigma_s.rgb`. (The values in for sigma_a.rgb are the complement of sigma_s.rgb)

![rainbow](https://user-images.githubusercontent.com/2104033/135336332-f4802cdb-1c65-4651-92ef-f7f5b85b3da4.png)
 
### Evaluation of Changes
#### Pros
- More control and better modelling.

#### Cons
- Increased code complexity. While the amount of additional rendering code is minimal, there is a lot of extra error checking that happens now because of the number of valid parameter combinations goes from 3 to 6. ie)
  - `float density`
  - `rgb density.rgb`
  - `float density.sigma_a` and `float density.sigma_s`
  - `float density.sigma_a` and `rgb density.sigma_s.rgb`
  - `rgb density.sigma_a.rgb` and `float density.sigma_s`
  - `rgb density.sigma_a.rgb` and `rgb density.sigma_s.rgb`