### PR TITLE
Initialize RGBGrid maxDensityGrid with allocator

### DIFF
--- a/src/pbrt/media.cpp
+++ b/src/pbrt/media.cpp
@@ -347,6 +347,8 @@ RGBGridMedium::RGBGridMedium(
     : bounds(bounds),
       renderFromMedium(renderFromMedium),
       phase(g),
+      maxDensityGridRes(16, 16, 16),
+      maxDensityGrid(alloc),
       sigma_aGrid(std::move(rgbA)),
       sigma_sGrid(std::move(rgbS)),
       sigScale(sigScale),
@@ -361,7 +363,6 @@ RGBGridMedium::RGBGridMedium(
     if (LeGrid)
         volumeGridBytes += LeGrid->BytesAllocated();
 
-    maxDensityGridRes = Point3i(16, 16, 16);
     maxDensityGrid.resize(maxDensityGridRes.x * maxDensityGridRes.y * maxDensityGridRes.z);
     // Compute maximum density for each _maxGrid_ cell
     int offset = 0;

--- a/src/pbrt/media.h
+++ b/src/pbrt/media.h
@@ -405,7 +405,6 @@ class RGBGridMedium {
     HGPhaseFunction phase;
     Point3i maxDensityGridRes;
     pstd::vector<Float> maxDensityGrid;
-    SampledGrid<Float> densityGrid;
     Float sigScale;
     pstd::optional<SampledGrid<RGBUnboundedSpectrum>> sigma_aGrid, sigma_sGrid;
     pstd::optional<SampledGrid<RGBIlluminantSpectrum>> LeGrid;


### PR DESCRIPTION
Ran into a GPU / CUDA bug when using the updated RGBGridMedium.
I was getting a CUDA error code: 700 and after a few PBRT_DBGs traced it back to 

https://github.com/mmp/pbrt-v4/blob/330aa0415a4d0b992334d737212586d4d818b974/src/pbrt/media.h#L156-L158

It was failing when looking into the `(*grid)[offset]`

When comparing RGBGridMedium to GridMedium (which wasn't crashing) I noticed that RGBGridMedium was missing
https://github.com/mmp/pbrt-v4/blob/330aa0415a4d0b992334d737212586d4d818b974/src/pbrt/media.cpp#L224-L225

Additionally I removed a superfluous `densityGrid` member variable.


ps - I learned a lot  from your changes! :smile:
