### PR TITLE
Resolve normalmap paths

### DIFF
--- a/src/pbrt/scene.cpp
+++ b/src/pbrt/scene.cpp
@@ -854,7 +854,7 @@ int BasicScene::AddMaterial(SceneEntity material) {
 }
 
 void BasicScene::startLoadingNormalMaps(const ParameterDictionary &parameters) {
-    std::string filename = parameters.GetOneString("normalmap", "");
+    std::string filename = ResolveFilename(parameters.GetOneString("normalmap", ""));
     if (filename.empty())
         return;
 


### PR DESCRIPTION
Tiny fix to wrap the normalmap parameter evaluation in a ResolveFilename.