### PR TITLE
Add rendercoordsys as a scene Option

### DIFF
--- a/src/pbrt/parser.cpp
+++ b/src/pbrt/parser.cpp
@@ -1037,7 +1037,7 @@ FormattingParserTarget::~FormattingParserTarget() {
 void FormattingParserTarget::Option(const std::string &name, const std::string &value,
                              FileLoc loc) {
     std::string nName = normalizeArg(name);
-    if (nName == "msereferenceimage" || nName == "msereferenceout")
+    if (nName == "msereferenceimage" || nName == "msereferenceout" || nName == "rendercoordsys")
         Printf("%sOption \"%s\" \"%s\"\n", indent(), name, value);
     else
         Printf("%sOption \"%s\" %s\n", indent(), name, value);

--- a/src/pbrt/parser.cpp
+++ b/src/pbrt/parser.cpp
@@ -1037,10 +1037,7 @@ FormattingParserTarget::~FormattingParserTarget() {
 void FormattingParserTarget::Option(const std::string &name, const std::string &value,
                              FileLoc loc) {
     std::string nName = normalizeArg(name);
-    if (nName == "msereferenceimage" || nName == "msereferenceout" || nName == "rendercoordsys")
-        Printf("%sOption \"%s\" \"%s\"\n", indent(), name, value);
-    else
-        Printf("%sOption \"%s\" %s\n", indent(), name, value);
+    Printf("%sOption \"%s\" %s\n", indent(), name, value);
 }
 
 void FormattingParserTarget::Identity(FileLoc loc) {

--- a/src/pbrt/scene.cpp
+++ b/src/pbrt/scene.cpp
@@ -522,6 +522,18 @@ void BasicSceneBuilder::Option(const std::string &name, const std::string &value
         if (value.size() < 3 || value.front() != '"' || value.back() != '"')
             ErrorExitDeferred(&loc, "%s: expected quoted string for option value", value);
         Options->mseReferenceOutput = value.substr(1, value.size() - 2);
+    } else if (nName == "rendercoordsys") {
+        if (value.size() < 3 || value.front() != '"' || value.back() != '"')
+            ErrorExitDeferred(&loc, "%s: expected quoted string for option value", value);
+        std::string renderCoordSys = value.substr(1, value.size() - 2);
+        if (renderCoordSys == "camera")
+            Options->renderingSpace = RenderingCoordinateSystem::Camera;
+        else if (renderCoordSys == "cameraworld")
+            Options->renderingSpace = RenderingCoordinateSystem::CameraWorld;
+        else if (renderCoordSys == "world")
+            Options->renderingSpace = RenderingCoordinateSystem::World;
+        else
+            ErrorExit("%s: unknown rendering coordinate system.", renderCoordSys);
     } else if (nName == "seed") {
         Options->seed = std::atoi(value.c_str());
     } else if (nName == "forcediffuse") {


### PR DESCRIPTION
Expose RenderingCoordinateSystem as a scene file Option (to complement the --render-coord-sys arg).

This also provides a workaround for #206 in how instances are interpolated.