### PR TITLE
In Wavefront Integrator check instance defintions for mediums

### DIFF
--- a/src/pbrt/wavefront/integrator.cpp
+++ b/src/pbrt/wavefront/integrator.cpp
@@ -100,11 +100,11 @@ WavefrontPathIntegrator::WavefrontPathIntegrator(
     for (const auto &shape : scene.animatedShapes)
         if (!shape.insideMedium.empty() || !shape.outsideMedium.empty())
             haveMedia = true;
-    for (const auto & [unused,  instanceDef ] : scene.instanceDefinitions) {
-        for (const auto &shape : instanceDef->shapes)
+    for (const auto &instanceDefinition: scene.instanceDefinitions) {
+        for (const auto &shape : instanceDefinition.second->shapes)
             if (!shape.insideMedium.empty() || !shape.outsideMedium.empty())
                 haveMedia = true;
-        for (const auto &shape : instanceDef->animatedShapes)
+        for (const auto &shape : instanceDefinition.second->animatedShapes)
             if (!shape.insideMedium.empty() || !shape.outsideMedium.empty())
                 haveMedia = true;
     }

--- a/src/pbrt/wavefront/integrator.cpp
+++ b/src/pbrt/wavefront/integrator.cpp
@@ -93,13 +93,21 @@ WavefrontPathIntegrator::WavefrontPathIntegrator(
     // launched... Thus, it will be true if there actually are no media,
     // but some "interface" materials are present in the scene.
     haveMedia = false;
-    // Check the shapes...
+    // Check the shapes and instance definitions...
     for (const auto &shape : scene.shapes)
         if (!shape.insideMedium.empty() || !shape.outsideMedium.empty())
             haveMedia = true;
     for (const auto &shape : scene.animatedShapes)
         if (!shape.insideMedium.empty() || !shape.outsideMedium.empty())
             haveMedia = true;
+    for (const auto & [unused,  instanceDef ] : scene.instanceDefinitions) {
+        for (const auto &shape : instanceDef->shapes)
+            if (!shape.insideMedium.empty() || !shape.outsideMedium.empty())
+                haveMedia = true;
+        for (const auto &shape : instanceDef->animatedShapes)
+            if (!shape.insideMedium.empty() || !shape.outsideMedium.empty())
+                haveMedia = true;
+    }
 
     // Textures
     LOG_VERBOSE("Starting to create textures");


### PR DESCRIPTION
# Summary
I noticed an assert failing when rendering with an instance object with a medium. In debug mode the following assert was triggering

https://github.com/mmp/pbrt-v4/blob/24d5abf6f27d11264028da1b8b57299a0c3aa03c/src/pbrt/wavefront/intersect.h#L58

This is due to `mediumSampleQueue` never being allocated because `haveMedia` was false. 
https://github.com/mmp/pbrt-v4/blob/24d5abf6f27d11264028da1b8b57299a0c3aa03c/src/pbrt/wavefront/integrator.cpp#L252-L253

While the shapes and animated shapes were checked for mediums the instance definitions were not.
https://github.com/mmp/pbrt-v4/blob/24d5abf6f27d11264028da1b8b57299a0c3aa03c/src/pbrt/wavefront/integrator.cpp#L95-L102

This PR adds checks for the shapes and animated shapes in the instance definitions.

# Test Scene
```
Film "rgb"
    "integer yresolution" [ 256 ]
    "integer xresolution" [ 256 ]
    "string filename" [ "issue_220.png" ]
PixelFilter "gaussian"
    "float yradius" [ 2 ]
    "float xradius" [ 2 ]
Sampler "zsobol"
    "integer pixelsamples" [ 128 ]
Integrator "volpath"
    "integer maxdepth" [ 5 ]

Accelerator "bvh"
Translate 0 0 10

Camera "perspective"
    "float screenwindow" [ -1 1 -1 1 ]
    "float fov" [ 30 ]

WorldBegin

LightSource "infinite"

MakeNamedMedium "red_fog" 
    "string type" "homogeneous"
    "rgb sigma_a" [ 0.1 0.9 0.9 ]
    "rgb sigma_s" [ 0.9 0.1 0.1 ]

ObjectBegin "test"
AttributeBegin
    Material "interface"
    MediumInterface "red_fog" ""
    Shape "sphere"
AttributeEnd
ObjectEnd

AttributeBegin
    ObjectInstance "test"
AttributeEnd
```
