### PR TITLE
Prevent NaN when CoatedConductor reflectance is 1

### DIFF
--- a/src/pbrt/materials.cpp
+++ b/src/pbrt/materials.cpp
@@ -359,7 +359,8 @@ CoatedConductorBxDF CoatedConductorMaterial::GetBxDF(TextureEvaluator texEval,
         ce = texEval(conductorEta, ctx, lambda);
         ck = texEval(k, ctx, lambda);
     } else {
-        SampledSpectrum r = texEval(reflectance, ctx, lambda);
+        // Avoid r==0 NaN case...
+        SampledSpectrum r = Clamp(texEval(reflectance, ctx, lambda), 0, .9999);
         ce = SampledSpectrum(1.f);
         ck = 2 * Sqrt(r) / Sqrt(ClampZero(SampledSpectrum(1) - r));
     }


### PR DESCRIPTION
# Summary

Prevent a NaN condition when CoatedConductor has a reflectance of 1.  This PR updates CoatedConductor to match Conductor's behaviour.

Existing check in ConductorMaterial -
https://github.com/mmp/pbrt-v4/blob/24d5abf6f27d11264028da1b8b57299a0c3aa03c/src/pbrt/materials.h#L504-L505

# Test Scene
```
Film "rgb"
    "integer yresolution" [ 512 ]
    "integer xresolution" [ 512 ]
    "string filename" [ "pbrt.exr" ]

PixelFilter "gaussian"
    "float yradius" [ 2 ]
    "float xradius" [ 2 ]
Sampler "zsobol"
    "integer pixelsamples" [ 128 ]
Integrator "volpath"

Accelerator "bvh"
Rotate -30 1 0 0
Translate 0 -1.5 3
Camera "perspective"
    "float screenwindow" [ -1 1 -1 1 ]
    "float fov" [ 50 ]

WorldBegin
AttributeBegin
    Rotate 90 1 0 0
    LightSource "distant"
AttributeEnd

MakeNamedMaterial "/mat/pbrt_material_coatedconductor1"
    "string type" [ "coatedconductor" ]
    "rgb reflectance" [ 1 1 1 ]

MakeNamedMaterial "/mat/pbrt_material_diffuse1"
    "rgb reflectance" [ 1 0 0 ]
    "string type" [ "diffuse" ]

AttributeBegin
    NamedMaterial "/mat/pbrt_material_coatedconductor1"
    Rotate -90 1 0 0
    Shape "disk"
        "float radius" [ 100 ]
AttributeEnd

AttributeBegin
    NamedMaterial "/mat/pbrt_material_diffuse1"
    Translate 0 0.4 0
    Shape "sphere"
        "float radius" [ 0.2 ]
AttributeEnd
```