### PR TITLE
Make submodule URLs consistent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "src/ext/zlib"]
 	path = src/ext/zlib
-	url = https://github.com/mitsuba-renderer/zlib
+	url = https://github.com/mitsuba-renderer/zlib.git
 [submodule "src/ext/ptex"]
 	path = src/ext/ptex
 	url = https://github.com/wdas/ptex.git
 [submodule "src/ext/double-conversion"]
 	path = src/ext/double-conversion
-	url = https://github.com/mmp/double-conversion
+	url = https://github.com/mmp/double-conversion.git
 [submodule "src/ext/stb"]
 	path = src/ext/stb
 	url = https://github.com/nothings/stb.git


### PR DESCRIPTION
Add `.git` to the double-conversion and zlib submodules URLs.