### PR TITLE
Fix address offsets in Spectral Film 

### DIFF
--- a/src/pbrt/film.cpp
+++ b/src/pbrt/film.cpp
@@ -868,9 +868,9 @@ SpectralFilm::SpectralFilm(FilmBaseParameters p, Float lambdaMin, Float lambdaMa
     for (Point2i p : pixelBounds) {
         Pixel &pixel = pixels[p];
         pixel.bucketSums = bucketWeightBuffer;
-        bucketWeightBuffer += NSpectrumSamples;
+        bucketWeightBuffer += nBuckets;
         pixel.weightSums = bucketWeightBuffer;
-        bucketWeightBuffer += NSpectrumSamples;
+        bucketWeightBuffer += nBuckets;
         pixel.bucketSplats = splatBuffer;
         splatBuffer += NSpectrumSamples;
     }


### PR DESCRIPTION
Hi,

Cool that you've added Spectral EXR support! I have a slight issue on my side when I try to open the file with SpectralViewer (RGB layers are correct).

The spectral layers are not correctly written in the Spectral Film. It seems the error comes from the creation of the main buffer: the address is offset by `NSpectrumSamples` (the number of multiplexed wavelengths in one ray?) instead of `nBuckets`.

Cheers.
