### PR TITLE
Fix process of directly visible light for LightPathIntegrator

### DIFF
--- a/src/pbrt/cpu/integrators.cpp
+++ b/src/pbrt/cpu/integrators.cpp
@@ -541,7 +541,7 @@ void LightPathIntegrator::EvaluatePixelSample(Point2i pPixel, int sampleIndex,
                     light.L(les->intr->p(), les->intr->n, les->intr->uv, cs->wi, lambda);
                 if (Le && Unoccluded(cs->pRef, cs->pLens)) {
                     // Compute visible light's path contribution and add to film
-                    SampledSpectrum L = Le * les->AbsCosTheta(cs->wi) * cs->Wi /
+                    SampledSpectrum L = Le * DistanceSquared(cs->pRef.p(), cs->pLens.p()) * cs->Wi /
                                         (lightPDF * pdf * cs->pdf);
                     camera.GetFilm().AddSplat(cs->pRaster, L, lambda);
                 }

--- a/src/pbrt/cpu/integrators.cpp
+++ b/src/pbrt/cpu/integrators.cpp
@@ -535,7 +535,7 @@ void LightPathIntegrator::EvaluatePixelSample(Point2i pPixel, int sampleIndex,
         pstd::optional<CameraWiSample> cs =
             camera.SampleWi(*les->intr, sampler.Get2D(), lambda);
         if (cs && cs->pdf != 0) {
-            if (Float pdf = light.PDF_Li(cs->pLens, cs->wi); pdf > 0) {
+            if (Float pdf = light.PDF_Li(cs->pLens, -cs->wi); pdf > 0) {
                 // Add light's emitted radiance if nonzero and light is visible
                 SampledSpectrum Le =
                     light.L(les->intr->p(), les->intr->n, les->intr->uv, cs->wi, lambda);


### PR DESCRIPTION
* Tested the Cornell Box scene on [Benedikt's page](https://benedikt-bitterli.me/resources/).

* old

![cornell-box lightpath 128 256x256](https://user-images.githubusercontent.com/6009211/165829419-d6711d6c-b78a-4ecd-baf8-e289eec30df1.png) ![cornell-box thinlens lightpath 128 256x256](https://user-images.githubusercontent.com/6009211/165829417-89e9403e-0b5f-4800-be92-bcc2f5995324.png)


* new

![cornell-box lightpath 128 256x256 fix](https://user-images.githubusercontent.com/6009211/165829416-35524106-0f11-4a76-94c9-c714546062f6.png) ![cornell-box thinlens lightpath 128 256x256 fix](https://user-images.githubusercontent.com/6009211/165829418-3550a31e-eb7b-40d5-b4cf-b3b0c591b066.png)


* new v.s. GT 

![cornell-box lightpath 128 256x256 fix diff](https://user-images.githubusercontent.com/6009211/165829421-0b4614b6-60bc-4672-8be6-b54b3ab45a4d.png) ![cornell-box thinlens lightpath 128 256x256 fix diff](https://user-images.githubusercontent.com/6009211/165829420-6c44adb4-60fd-4817-9d9f-de431ce2c5ac.png)

