### PR TITLE
Fix TaggedPointer ambiguous `DispatchCPU()` call issue when instantiated with 8x types.

### DIFF
--- a/src/pbrt/util/taggedptr.h
+++ b/src/pbrt/util/taggedptr.h
@@ -251,6 +251,32 @@ PBRT_CPU_GPU R Dispatch(F &&func, void *ptr, int index) {
 
 template <typename F, typename R, typename T0, typename T1, typename T2, typename T3,
           typename T4, typename T5, typename T6, typename T7>
+PBRT_CPU_GPU R Dispatch(F &&func, const void *ptr, int index) {
+    DCHECK_GE(index, 0);
+    DCHECK_LT(index, 8);
+
+    switch (index) {
+    case 0:
+        return func((const T0 *)ptr);
+    case 1:
+        return func((const T1 *)ptr);
+    case 2:
+        return func((const T2 *)ptr);
+    case 3:
+        return func((const T3 *)ptr);
+    case 4:
+        return func((const T4 *)ptr);
+    case 5:
+        return func((const T5 *)ptr);
+    case 6:
+        return func((const T6 *)ptr);
+    default:
+        return func((const T7 *)ptr);
+    }
+}
+
+template <typename F, typename R, typename T0, typename T1, typename T2, typename T3,
+          typename T4, typename T5, typename T6, typename T7>
 PBRT_CPU_GPU R Dispatch(F &&func, void *ptr, int index) {
     DCHECK_GE(index, 0);
     DCHECK_LT(index, 8);
@@ -276,7 +302,8 @@ PBRT_CPU_GPU R Dispatch(F &&func, void *ptr, int index) {
 }
 
 template <typename F, typename R, typename T0, typename T1, typename T2, typename T3,
-          typename T4, typename T5, typename T6, typename T7, typename... Ts>
+          typename T4, typename T5, typename T6, typename T7, typename... Ts,
+          typename = typename std::enable_if_t<(sizeof...(Ts) > 0)>>
 PBRT_CPU_GPU R Dispatch(F &&func, const void *ptr, int index) {
     DCHECK_GE(index, 0);
 
@@ -303,7 +330,8 @@ PBRT_CPU_GPU R Dispatch(F &&func, const void *ptr, int index) {
 }
 
 template <typename F, typename R, typename T0, typename T1, typename T2, typename T3,
-          typename T4, typename T5, typename T6, typename T7, typename... Ts>
+          typename T4, typename T5, typename T6, typename T7, typename... Ts,
+          typename = typename std::enable_if_t<(sizeof...(Ts) > 0)>>
 PBRT_CPU_GPU R Dispatch(F &&func, void *ptr, int index) {
     DCHECK_GE(index, 0);
 
@@ -561,6 +589,32 @@ auto DispatchCPU(F &&func, void *ptr, int index) {
 
 template <typename F, typename R, typename T0, typename T1, typename T2, typename T3,
           typename T4, typename T5, typename T6, typename T7>
+auto DispatchCPU(F &&func, const void *ptr, int index) {
+    DCHECK_GE(index, 0);
+    DCHECK_LT(index, 8);
+
+    switch (index) {
+    case 0:
+        return func((const T0 *)ptr);
+    case 1:
+        return func((const T1 *)ptr);
+    case 2:
+        return func((const T2 *)ptr);
+    case 3:
+        return func((const T3 *)ptr);
+    case 4:
+        return func((const T4 *)ptr);
+    case 5:
+        return func((const T5 *)ptr);
+    case 6:
+        return func((const T6 *)ptr);
+    default:
+        return func((const T7 *)ptr);
+    }
+}
+
+template <typename F, typename R, typename T0, typename T1, typename T2, typename T3,
+          typename T4, typename T5, typename T6, typename T7>
 auto DispatchCPU(F &&func, void *ptr, int index) {
     DCHECK_GE(index, 0);
     DCHECK_LT(index, 8);
@@ -586,7 +640,8 @@ auto DispatchCPU(F &&func, void *ptr, int index) {
 }
 
 template <typename F, typename R, typename T0, typename T1, typename T2, typename T3,
-          typename T4, typename T5, typename T6, typename T7, typename... Ts>
+          typename T4, typename T5, typename T6, typename T7, typename... Ts,
+          typename = typename std::enable_if_t<(sizeof...(Ts) > 0)>>
 auto DispatchCPU(F &&func, const void *ptr, int index) {
     DCHECK_GE(index, 0);
 
@@ -613,7 +668,8 @@ auto DispatchCPU(F &&func, const void *ptr, int index) {
 }
 
 template <typename F, typename R, typename T0, typename T1, typename T2, typename T3,
-          typename T4, typename T5, typename T6, typename T7, typename... Ts>
+          typename T4, typename T5, typename T6, typename T7, typename... Ts,
+          typename = typename std::enable_if_t<(sizeof...(Ts) > 0)>>
 auto DispatchCPU(F &&func, void *ptr, int index) {
     DCHECK_GE(index, 0);
 


### PR DESCRIPTION
Hi,

I think there might be an issue in the implementaion of `Dispatch()` and `DispatchCPU()` in taggedptr.h:

https://github.com/mmp/pbrt-v4/blob/bc25558763649eb25052a29299594d62c67ed39f/src/pbrt/util/taggedptr.h#L562-L586

https://github.com/mmp/pbrt-v4/blob/bc25558763649eb25052a29299594d62c67ed39f/src/pbrt/util/taggedptr.h#L615-L640

# Ambiguous `DispatchCPU()` calls

Note that template parameter pack `Ts` here could accept zero or more template arguments, so these two functions will be ambiguous.

So once I have a handle struct that inherits `TaggedPointer` instantiated with 8x types:

```cpp
struct HandleWithEightConcreteTypes : public TaggedPointer<IntType<0>, IntType<1>, IntType<2>, IntType<3>,
                                                           IntType<4>, IntType<5>, IntType<6>, IntType<7>> {
    using TaggedPointer::TaggedPointer;

    int func() {
        auto f = [&](auto ptr) { return ptr->func(); };
        return DispatchCPU(f);
    }
};
```

This produces following errors (MSVC 19.31.31105, Windows SDK 10.0.19041.0):

> 1>taggedptr_test.cpp
> 1>D:\Project\pbrt-v4\src\pbrt/util/taggedptr.h(794,24): error C2668: 'pbrt::detail::DispatchCPU': ambiguous call to overloaded function
> 1>D:\Project\pbrt-v4\src\pbrt/util/taggedptr.h(617,6): message : could be 'auto pbrt::detail::DispatchCPU<F,R,IntType<0>,IntType<1>,IntType<2>,IntType<3>,IntType<4>,IntType<5>,IntType<6>,IntType<7>,>(F,void *,int)'
> 1>        with
> 1>        [
> 1>            F=HandleWithEightConcreteTypes::func::<lambda_5c6676a9b01327d7978d5d6b963055d3> &
> 1>        ]
> 1>D:\Project\pbrt-v4\src\pbrt/util/taggedptr.h(564,6): message : or       'auto pbrt::detail::DispatchCPU<F,R,IntType<0>,IntType<1>,IntType<2>,IntType<3>,IntType<4>,IntType<5>,IntType<6>,IntType<7>>(F,void *,int)'
> 1>        with
> 1>        [
> 1>            F=HandleWithEightConcreteTypes::func::<lambda_5c6676a9b01327d7978d5d6b963055d3> &
> 1>        ]
> 1>D:\Project\pbrt-v4\src\pbrt/util/taggedptr.h(791,1): message : while trying to match the argument list '(HandleWithEightConcreteTypes::func::<lambda_5c6676a9b01327d7978d5d6b963055d3>, void *, unsigned int)'
> 1>D:\Project\pbrt-v4\src\pbrt\util\taggedptr_test.cpp(41): message : see reference to function template instantiation 'decltype(auto) pbrt::TaggedPointer<IntType<0>,IntType<1>,IntType<2>,IntType<3>,IntType<4>,IntType<5>,IntType<6>,IntType<7>>::DispatchCPU<HandleWithEightConcreteTypes::func::<lambda_5c6676a9b01327d7978d5d6b963055d3>&>(F)' being compiled
> 1>        with
> 1>        [
> 1>            F=HandleWithEightConcreteTypes::func::<lambda_5c6676a9b01327d7978d5d6b963055d3> &
> 1>        ]
> 1>D:\Project\pbrt-v4\src\pbrt\util\taggedptr_test.cpp(41,1): error C2440: 'return': cannot convert from 'void' to 'int'
> 1>D:\Project\pbrt-v4\src\pbrt\util\taggedptr_test.cpp(41,27): message : Expressions of type void cannot be converted to other types

# No matching overloaded functions for `DispatchCPU()` const version

I also found we do not have `const void*` overloading (the one without parameter pack) for `DispatchCPU()`:
```cpp
// We have this!
template <typename F, typename R, typename T0, typename T1, typename T2, typename T3,
          typename T4, typename T5, typename T6, typename T7, typename... Ts>
auto DispatchCPU(F &&func, const void *ptr, int index) {...}

// But not this!
template <typename F, typename R, typename T0, typename T1, typename T2, typename T3,
          typename T4, typename T5, typename T6, typename T7>
auto DispatchCPU(F &&func, const void *ptr, int index){...}
```

So when I play with the `const` member function version with the above example:

```cpp
struct HandleWithEightConcreteTypes : public TaggedPointer<IntType<0>, IntType<1>, IntType<2>, IntType<3>,
                                                           IntType<4>, IntType<5>, IntType<6>, IntType<7>> {
    using TaggedPointer::TaggedPointer;
    // const member function this time!
    int cfunc() const {
        auto f = [&](auto ptr) { return ptr->cfunc(); };
        return DispatchCPU(f);
    }
};
```

It produces following errors:

> 1>taggedptr_test.cpp
> 1>D:\Project\pbrt-v4\src\pbrt/util/taggedptr.h(611,16): error C2672: 'DispatchCPU': no matching overloaded function found
> 1>D:\Project\pbrt-v4\src\pbrt/util/taggedptr.h(798): message : see reference to function template instantiation 'int pbrt::detail::DispatchCPU<F,R,IntType<0>,IntType<1>,IntType<2>,IntType<3>,IntType<4>,IntType<5>,IntType<6>,IntType<7>,>(F,const void *,int)' being compiled
> 1>        with
> 1>        [
> 1>            F=HandleWithEightConcreteTypes::cfunc::<lambda_c452c80f244afb4a18f74239fd2316ae> &
> 1>        ]
> 1>D:\Project\pbrt-v4\src\pbrt\util\taggedptr_test.cpp(45): message : see reference to function template instantiation 'decltype(auto) pbrt::TaggedPointer<IntType<0>,IntType<1>,IntType<2>,IntType<3>,IntType<4>,IntType<5>,IntType<6>,IntType<7>>::DispatchCPU<HandleWithEightConcreteTypes::cfunc::<lambda_c452c80f244afb4a18f74239fd2316ae>&>(F) const' being compiled
> 1>        with
> 1>        [
> 1>            F=HandleWithEightConcreteTypes::cfunc::<lambda_c452c80f244afb4a18f74239fd2316ae> &
> 1>        ]
> 1>D:\Project\pbrt-v4\src\pbrt/util/taggedptr.h(611,16): error C2783: 'auto pbrt::detail::DispatchCPU(F &&,const void *,int)': could not deduce template argument for 'T'
> 1>D:\Project\pbrt-v4\src\pbrt/util/taggedptr.h(333): message : see declaration of 'pbrt::detail::DispatchCPU'
> 1>D:\Project\pbrt-v4\src\pbrt/util/taggedptr.h(590,56): error C3487: 'void': all return expressions must deduce to the same type: previously it was 'int'

It does not make sense to call `default: return DispatchCPU<F, R, Ts...>(func, ptr, index - 8);` in this case, since `Ts` is empty.

# Possible solution
I am not really good at template metaprogramming but I think we could use `std::enable_if` to avoid the variadic template version of `DispatchCPU()` when necessary and add the `const void*` `DispatchCPU` version.

`Dispatch()` also has the same issue so I changed that as well.
Feel free to take a look at code changes and see if this is really an issue...


Cheers!