### PR TITLE
Add hint and refactor check for squareness of env map

### DIFF
--- a/src/pbrt/lights.cpp
+++ b/src/pbrt/lights.cpp
@@ -628,8 +628,7 @@ GoniometricLight *GoniometricLight::Create(const Transform &renderFromLight,
                       "a light.",
                       texname);
 
-        if (imageAndMetadata.image.Resolution().x !=
-            imageAndMetadata.image.Resolution().y)
+        if (imageAndMetadata.image.IsNonSquare())
             ErrorExit("%s: image resolution (%d, %d) is non-square. It's unlikely "
                       "this is an equal-area environment map.",
                       texname, imageAndMetadata.image.Resolution().x,
@@ -1026,7 +1025,7 @@ ImageInfiniteLight::ImageInfiniteLight(Transform renderFromLight, Image im,
                   filename);
     CHECK_EQ(3, channelDesc.size());
     CHECK(channelDesc.IsIdentity());
-    if (image.Resolution().x != image.Resolution().y)
+    if (image.IsNonSquare())
         ErrorExit("%s: image resolution (%d, %d) is non-square. It's unlikely "
                   "this is an equal area environment map.",
                   filename, image.Resolution().x, image.Resolution().y);
@@ -1128,7 +1127,7 @@ PortalImageInfiniteLight::PortalImageInfiniteLight(
     CHECK_EQ(3, channelDesc.size());
     CHECK(channelDesc.IsIdentity());
 
-    if (equalAreaImage.Resolution().x != equalAreaImage.Resolution().y)
+    if (equalAreaImage.IsNonSquare())
         ErrorExit("%s: image resolution (%d, %d) is non-square. It's unlikely "
                   "this is an equal area environment map.",
                   filename, equalAreaImage.Resolution().x, equalAreaImage.Resolution().y);

--- a/src/pbrt/lights.cpp
+++ b/src/pbrt/lights.cpp
@@ -630,7 +630,9 @@ GoniometricLight *GoniometricLight::Create(const Transform &renderFromLight,
 
         if (imageAndMetadata.image.IsNonSquare())
             ErrorExit("%s: image resolution (%d, %d) is non-square. It's unlikely "
-                      "this is an equal-area environment map.",
+                      "that this is an equal-area environment map. Consider to use "
+                      "the command makeequiarea of the helper program imgtool to "
+                      "resolve this issue.",
                       texname, imageAndMetadata.image.Resolution().x,
                       imageAndMetadata.image.Resolution().y);
 
@@ -1027,7 +1029,9 @@ ImageInfiniteLight::ImageInfiniteLight(Transform renderFromLight, Image im,
     CHECK(channelDesc.IsIdentity());
     if (image.IsNonSquare())
         ErrorExit("%s: image resolution (%d, %d) is non-square. It's unlikely "
-                  "this is an equal area environment map.",
+                  "that this is an equal-area environment map. Consider to use "
+                  "the command makeequiarea of the helper program imgtool to "
+                  "resolve this issue.",
                   filename, image.Resolution().x, image.Resolution().y);
     Array2D<Float> d = image.GetSamplingDistribution();
     Bounds2f domain = Bounds2f(Point2f(0, 0), Point2f(1, 1));
@@ -1129,7 +1133,9 @@ PortalImageInfiniteLight::PortalImageInfiniteLight(
 
     if (equalAreaImage.IsNonSquare())
         ErrorExit("%s: image resolution (%d, %d) is non-square. It's unlikely "
-                  "this is an equal area environment map.",
+                  "that this is an equal-area environment map. Consider to use "
+                  "the command makeequiarea of the helper program imgtool to "
+                  "resolve this issue.",
                   filename, equalAreaImage.Resolution().x, equalAreaImage.Resolution().y);
 
     if (p.size() != 4)

--- a/src/pbrt/util/image.cpp
+++ b/src/pbrt/util/image.cpp
@@ -156,6 +156,10 @@ bool Image::HasAnyNaNPixels() const {
     return false;
 }
 
+bool Image::IsNonSquare() const {
+    return resolution.x != resolution.y;
+}
+
 Image Image::GaussianFilter(const ImageChannelDesc &desc, int halfWidth,
                             Float sigma) const {
     // Compute filter weights

--- a/src/pbrt/util/image.h
+++ b/src/pbrt/util/image.h
@@ -321,6 +321,7 @@ class Image {
 
     bool HasAnyInfinitePixels() const;
     bool HasAnyNaNPixels() const;
+    bool IsNonSquare() const;
 
     ImageChannelValues MAE(const ImageChannelDesc &desc, const Image &ref,
                            Image *errorImage = nullptr) const;


### PR DESCRIPTION
I stumbled over the error message of non-square environments maps and it took some time before I found out that I can use the `imgtool` to solve this issue. Also, since the square-check is spelled out three times, I thought it might be better to move it into its own function.