### PR TITLE
Check to see if a filepath exists before making absolute

### DIFF
--- a/src/pbrt/util/file.cpp
+++ b/src/pbrt/util/file.cpp
@@ -69,8 +69,11 @@ std::string RemoveExtension(std::string filename) {
 std::string ResolveFilename(std::string filename) {
     if (searchDirectory.empty() || filename.empty() || IsAbsolutePath(filename))
         return filename;
-    else
-        return (searchDirectory / filesystem::path(filename)).make_absolute().str();
+
+    filesystem::path filepath = searchDirectory / filesystem::path(filename);
+    if (filepath.exists())
+        return filepath.make_absolute().str();
+    return filename;
 }
 
 std::vector<std::string> MatchingFilenames(std::string filenameBase) {


### PR DESCRIPTION
One approach to solving issue #280

ResolveFilename() calls filesystem::path::make_absolute() which does a file stat and errors if the file doesn't exist. This commit adds an additional check and only adds the search path if the resulting file exists. Otherwise it leaves the path alone.