### PR TITLE
Avoid Clang 14 error compiling under Windows

### DIFF
--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -110,7 +110,7 @@ set (PTEX_BUILD_SHARED_LIBS OFF CACHE BOOL " " FORCE)
 
 set (CMAKE_MACOSX_RPATH 1)
 if (WIN32)
-  add_definitions (/D PTEX_STATIC)
+  add_definitions (/DPTEX_STATIC)
 endif ()
 
 add_subdirectory (ptex)


### PR DESCRIPTION
Build with Clang 14 under Windows show this error
```
clang-14: error: no such file or directory: '/D'
clang-14: error: no such file or directory: 'PTEX_STATIC'
```
This commit fix this and is also OK for MSVC