### PR TITLE
Add a option to use arbitrary names for grids

### DIFF
--- a/src/pbrt/media.cpp
+++ b/src/pbrt/media.cpp
@@ -633,7 +633,7 @@ NanoVDBMedium *NanoVDBMedium::Create(const ParameterDictionary &parameters,
     nanovdb::GridHandle<NanoVDBBuffer> temperatureGrid;
     std::string temperaturename =
         parameters.GetOneString("temperaturename", "temperature");
-    temperatureGrid = readGrid<NanoVDBBuffer>(filename, "temperature", loc, alloc);
+    temperatureGrid = readGrid<NanoVDBBuffer>(filename, temperaturename, loc, alloc);
 
     Float LeScale = parameters.GetOneFloat("LeScale", 1.f);
     Float temperatureCutoff = parameters.GetOneFloat("temperaturecutoff", 0.f);


### PR DESCRIPTION
Sometimes .nvdb files use arbitrary names for grids. This change adds two options for the user to specify different names for 'density' and 'temperature' grids.