### PR TITLE
Corrected denoiseAlpha parameter type

### DIFF
--- a/src/pbrt/gpu/denoiser.cpp
+++ b/src/pbrt/gpu/denoiser.cpp
@@ -101,7 +101,11 @@ void Denoiser::Denoise(RGB *rgb, Normal3f *n, RGB *albedo, RGB *result) {
         CUdeviceptr(scratchBuffer), memorySizes.withoutOverlapScratchSizeInBytes));
 
     OptixDenoiserParams params = {};
+#if (OPTIX_VERSION >= 70500)
     params.denoiseAlpha = OPTIX_DENOISER_ALPHA_MODE_COPY;
+#else
+    params.denoiseAlpha = 0;
+#endif
     params.hdrIntensity = CUdeviceptr(intensity);
     params.blendFactor = 0;  // TODO what should this be??
 

--- a/src/pbrt/gpu/denoiser.cpp
+++ b/src/pbrt/gpu/denoiser.cpp
@@ -101,7 +101,7 @@ void Denoiser::Denoise(RGB *rgb, Normal3f *n, RGB *albedo, RGB *result) {
         CUdeviceptr(scratchBuffer), memorySizes.withoutOverlapScratchSizeInBytes));
 
     OptixDenoiserParams params = {};
-    params.denoiseAlpha = 0;
+    params.denoiseAlpha = OPTIX_DENOISER_ALPHA_MODE_COPY;
     params.hdrIntensity = CUdeviceptr(intensity);
     params.blendFactor = 0;  // TODO what should this be??
 


### PR DESCRIPTION
During experiment with the PBRT build failed due to parameter type mismatch.

nVIDIA OptiX-SDK-7.5.0
F36
GCC Version 12.1.1