### PR TITLE
Fix nullptr access reported in issue #293

### DIFF
--- a/src/pbrt/lights.cpp
+++ b/src/pbrt/lights.cpp
@@ -916,13 +916,13 @@ DiffuseAreaLight *DiffuseAreaLight::Create(const Transform &renderFromLight,
         // radiance such that the user-defined power will be the actual power
         // emitted by the light.
         Float k_e = 1;
-        // Get the appropriate luminance vector from the image colour space
-        RGB lum = imageColorSpace->LuminanceVector();
         // we need to know which channels correspond to R, G and B
         // we know that the channelDesc is valid as we would have exited in the
         // block above otherwise
         ImageChannelDesc channelDesc = image.GetChannelDesc({"R", "G", "B"});
         if (image) {
+            // Get the appropriate luminance vector from the image colour space
+            RGB lum = imageColorSpace->LuminanceVector();
             k_e = 0;
             // Assume no distortion in the mapping, FWIW...
             for (int y = 0; y < image.Resolution().y; ++y)


### PR DESCRIPTION
If no texture is supplied then imageColorSpace is still a nullptr

https://github.com/mmp/pbrt-v4/blob/8f2d8527af2bad5f99d31706c5f580178bf8d569/src/pbrt/lights.cpp#L880

and will fail when accessed here

https://github.com/mmp/pbrt-v4/blob/8f2d8527af2bad5f99d31706c5f580178bf8d569/src/pbrt/lights.cpp#L920

