### PR TITLE
Ignore sample count and run forever in interactive mode.

### DIFF
--- a/src/pbrt/wavefront/integrator.cpp
+++ b/src/pbrt/wavefront/integrator.cpp
@@ -333,8 +333,8 @@ Float WavefrontPathIntegrator::Render() {
 
     ProgressReporter progress(lastSampleIndex - firstSampleIndex, "Rendering",
                               Options->quiet || Options->interactive, Options->useGPU);
-    for (int sampleIndex = firstSampleIndex; sampleIndex < lastSampleIndex;
-         ++sampleIndex) {
+    int sampleIndex = firstSampleIndex;
+    while (true) {
         // Attempt to work around issue #145.
 #if !(defined(PBRT_IS_WINDOWS) && defined(PBRT_BUILD_GPU_RENDERER) && \
       __CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 1)
@@ -465,6 +465,10 @@ Float WavefrontPathIntegrator::Render() {
             }
         }
 
+        ++sampleIndex;
+        if (!gui && sampleIndex == lastSampleIndex) {
+                break;
+        }
         progress.Update();
     }
 


### PR DESCRIPTION
When using a low sample count, pbrt suddenly exits in interactive mode. It is possible to set the sample count to a very high number to prevent this, but I think it is better to just ignore the sample count and run forever in interactive mode.