### PR TITLE
Remove needless lock from log.cpp/ElapsedSeconds

### DIFF
--- a/src/pbrt/util/log.cpp
+++ b/src/pbrt/util/log.cpp
@@ -49,10 +49,8 @@ namespace pbrt {
 
 namespace {
 
+// `start` is accessed concurrently, but all of them are reads.
 float ElapsedSeconds() {
-    static std::mutex mutex;
-    std::lock_guard<std::mutex> lock(mutex);
-
     using clock = std::chrono::steady_clock;
     static clock::time_point start = clock::now();
 


### PR DESCRIPTION
Static local variable `start` was guarded by a mutex, but all concurrent accesses are reads.