### PR TITLE
Fix crash on Wayland.

### DIFF
--- a/src/pbrt/gpu/cudagl.h
+++ b/src/pbrt/gpu/cudagl.h
@@ -352,7 +352,7 @@ CUDAOutputBuffer<PIXEL_FORMAT>::CUDAOutputBuffer(int32_t width, int32_t height) 
     CUDA_CHECK(cudaGetDevice(&current_device));
     CUDA_CHECK(cudaDeviceGetAttribute(&is_display_device, cudaDevAttrKernelExecTimeout,
                                       current_device));
-    if (getenv("XDG_SESSION_TYPE") != std::string("wayland")) {
+    if (getenv("XDG_SESSION_TYPE") == nullptr || getenv("XDG_SESSION_TYPE") != std::string("wayland")) {
         if (!is_display_device)
             LOG_FATAL("GL interop is only available on display device.");
     }

--- a/src/pbrt/gpu/cudagl.h
+++ b/src/pbrt/gpu/cudagl.h
@@ -352,9 +352,10 @@ CUDAOutputBuffer<PIXEL_FORMAT>::CUDAOutputBuffer(int32_t width, int32_t height) 
     CUDA_CHECK(cudaGetDevice(&current_device));
     CUDA_CHECK(cudaDeviceGetAttribute(&is_display_device, cudaDevAttrKernelExecTimeout,
                                       current_device));
-    if (!is_display_device)
-        LOG_FATAL("GL interop is only available on display device.");
-
+    if (getenv("XDG_SESSION_TYPE") != std::string("wayland")) {
+        if (!is_display_device)
+            LOG_FATAL("GL interop is only available on display device.");
+    }
     CUDA_CHECK(cudaGetDevice(&m_device_idx));
 
     m_width = width;


### PR DESCRIPTION
`./pbrt --gpu --interactive ~/src/pbrt-v4-scenes/bmw-m6/bmw-m6.pbrt` crashes under Wayland with

```
[ tid 20700 @     0.000s gpu/cudagl.h:356 ] FATAL GL interop is only available on display device.
(./pbrt                                  )	0x0x5653c36d980a - pbrt::PrintStackTrace() + 0x3a
(./pbrt                                  )	0x0x5653c36d9ab1 - pbrt::CheckCallbackScope::Fail() + 0x21
(./pbrt                                  )	0x0x5653c373d9e2 - pbrt::LogFatal(pbrt::LogLevel, char const*, int, char const*) + 0xf2
(./pbrt                                  )	0x0x5653c3a7c059 - pbrt::CUDAOutputBuffer<pbrt::RGB>::CUDAOutputBuffer(int, int) + 0x4e9
(./pbrt                                  )	0x0x5653c3a7799a - pbrt::GUI::GUI(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, pbrt::Vector2<int>, pbrt::Bounds3<float>) + 0x33a
(./pbrt                                  )	0x0x5653c39c4c1c - pbrt::WavefrontPathIntegrator::Render() + 0x28c
(./pbrt                                  )	0x0x5653c37fa4ab - pbrt::RenderWavefront(pbrt::BasicScene&) + 0x29b
(./pbrt                                  )	0x0x5653c3535267 - main + 0x1a27
(/lib/x86_64-linux-gnu/libc.so.6         )	0x0x7fb9dee23510 - (unknown) + 0x23510
(/lib/x86_64-linux-gnu/libc.so.6         )	0x0x7fb9dee235c9 - __libc_start_main + 0x89
(./pbrt                                  )	0x0x5653c353d5d5 - _start + 0x25
```
