### PR TITLE
Silent build warnings about deprecated 'snprintf'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,9 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL Linux)
 else ()
   message (SEND_ERROR "Unknown system name: " + CMAKE_SYSTEM_NAME)
 endif()
-
+if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  add_definitions(-Wno-deprecated-declarations) # silent deprecated 'snprintf' message under MacOS arm64
+endif()
 # libgoogle-perftools-dev
 find_library (PROFILE_LIB profiler)
 if (NOT PROFILE_LIB)


### PR DESCRIPTION
This directive silences many annoying and perhaps unused warning messages under MacOS arm64 about that a few of printf's are now deprecated