### PR TITLE
Take the incident `IOR` into account for the `CoatedConductorMaterial`

### DIFF
--- a/src/pbrt/materials.cpp
+++ b/src/pbrt/materials.cpp
@@ -364,14 +364,16 @@ CoatedConductorBxDF CoatedConductorMaterial::GetBxDF(TextureEvaluator texEval,
 
     SampledSpectrum ce, ck;
     if (conductorEta) {
-        ce = texEval(conductorEta, ctx, lambda) / ieta;
-        ck = texEval(k, ctx, lambda) / ieta;
+        ce = texEval(conductorEta, ctx, lambda);
+        ck = texEval(k, ctx, lambda);
     } else {
         // Avoid r==0 NaN case...
         SampledSpectrum r = Clamp(texEval(reflectance, ctx, lambda), 0, .9999);
         ce = SampledSpectrum(1.f);
         ck = 2 * Sqrt(r) / Sqrt(ClampZero(SampledSpectrum(1) - r));
     }
+    ce /= ieta;
+    ck /= ieta;
 
     Float curough = texEval(conductorURoughness, ctx);
     Float cvrough = texEval(conductorVRoughness, ctx);

--- a/src/pbrt/materials.cpp
+++ b/src/pbrt/materials.cpp
@@ -364,8 +364,8 @@ CoatedConductorBxDF CoatedConductorMaterial::GetBxDF(TextureEvaluator texEval,
 
     SampledSpectrum ce, ck;
     if (conductorEta) {
-        ce = texEval(conductorEta, ctx, lambda);
-        ck = texEval(k, ctx, lambda);
+        ce = texEval(conductorEta, ctx, lambda) / ieta;
+        ck = texEval(k, ctx, lambda) / ieta;
     } else {
         // Avoid r==0 NaN case...
         SampledSpectrum r = Clamp(texEval(reflectance, ctx, lambda), 0, .9999);


### PR DESCRIPTION
This takes the incident index of refraction into account when setting the relative index of refraction for coated conductors.
fixes #342