### PR TITLE
Fix fatal error on Hair material

### DIFF
--- a/src/pbrt/materials.h
+++ b/src/pbrt/materials.h
@@ -379,8 +379,8 @@ class HairMaterial {
     template <typename TextureEvaluator>
     PBRT_CPU_GPU HairBxDF GetBxDF(TextureEvaluator texEval, MaterialEvalContext ctx,
                                   SampledWavelengths &lambda) const {
-        Float bm = std::max<Float>(1e-2, texEval(beta_m, ctx));
-        Float bn = std::max<Float>(1e-2, texEval(beta_n, ctx));
+        Float bm = std::max<Float>(1e-2, std::min<Float>(1.0, texEval(beta_m, ctx)));
+        Float bn = std::max<Float>(1e-2, std::min<Float>(1.0, texEval(beta_n, ctx)));
         Float a = texEval(alpha, ctx);
         Float e = texEval(eta, ctx);
 


### PR DESCRIPTION
This change fix a error on Hair material when the upper value for 'beta_m' or 'beta_n' is greatest than 1.0.
More details in this bug report: https://github.com/mmp/pbrt-v4/issues/338