### PR TITLE
fix broken url

### DIFF
--- a/src/pbrt/util/math.h
+++ b/src/pbrt/util/math.h
@@ -590,7 +590,7 @@ PBRT_CPU_GPU inline CompensatedFloat InnerProduct(Float a, Float b) {
 }
 
 // Accurate dot products with FMA: Graillat et al.,
-// http://rnc7.loria.fr/louvet_poster.pdf
+// https://www-pequan.lip6.fr/~graillat/papers/posterRNC7.pdf
 //
 // Accurate summation, dot product and polynomial evaluation in complex
 // floating point arithmetic, Graillat and Menissier-Morain.


### PR DESCRIPTION
`src/pbrt/util/math.h`: url `http://rnc7.loria.fr/louvet_poster.pdf` is broken, use `https://www-pequan.lip6.fr/~graillat/papers/posterRNC7.pdf` instead