### PR TITLE
Fix displacement for plymesh

### DIFF
--- a/src/pbrt/util/mesh.h
+++ b/src/pbrt/util/mesh.h
@@ -99,13 +99,15 @@ struct TriQuadMesh {
         outputMesh.ConvertToOnlyTriangles();
         if (outputMesh.n.empty())
             outputMesh.ComputeNormals();
+        std::vector<int> oldTriIndices(outputMesh.triIndices);
         outputMesh.triIndices.clear();
 
         // Refine
         HashMap<std::pair<int, int>, int, HashIntPair> edgeSplit({});
-        for (int i = 0; i < triIndices.size() / 3; ++i)
-            outputMesh.Refine(dist, maxDist, triIndices[3 * i], triIndices[3 * i + 1],
-                              triIndices[3 * i + 2], edgeSplit);
+        for (int i = 0; i < oldTriIndices.size() / 3; ++i)
+            outputMesh.Refine(dist, maxDist, oldTriIndices[3 * i],
+                              oldTriIndices[3 * i + 1], oldTriIndices[3 * i + 2],
+                              edgeSplit);
 
         // Displace
         displace(outputMesh.p.data(), outputMesh.n.data(), outputMesh.uv.data(),


### PR DESCRIPTION
This patch attempts to fix the bug when displacing plymesh containing a quad.
The bug only exists when running with CPU only.

Example scene (taken from [pbrt.org](https://pbrt.org/fileformat-v4#example)):
```
LookAt 3 4 1.5  # eye
       .5 .5 0  # look at point
       0 0 1    # up vector
Camera "perspective" "float fov" 45

Sampler "halton" "integer pixelsamples" 128
Integrator "volpath"
Film "rgb" "string filename" "simple.png"
     "integer xresolution" [400] "integer yresolution" [400]

WorldBegin

# uniform blue-ish illumination from all directions
LightSource "infinite" "rgb L" [ .4 .45 .5 ]

# approximate the sun
LightSource "distant"  "point3 from" [ -30 40  100 ]
   "blackbody L" 3000 "float scale" 1.5

Texture "white"
  "float" "imagemap"
  "string filename" "white.png"

AttributeBegin
  Material "coateddiffuse"
  Shape "plymesh"
    "string filename" "sphere.ply"
    "texture displacement" "white"
AttributeEnd

AttributeBegin
  Texture "checks" "spectrum" "checkerboard"
          "float uscale" [16] "float vscale" [16]
          "rgb tex1" [.1 .1 .1] "rgb tex2" [.8 .8 .8]
  Material "diffuse" "texture reflectance" "checks"
  Translate 0 0 -1
  Shape "bilinearmesh"
      "point3 P" [ -20 -20 0   20 -20 0   -20 20 0   20 20 0 ]
      "point2 uv" [ 0 0   1 0    1 1   0 1 ]
AttributeEnd
```
where ```white.png``` is a grayscale png file with all pixel value 255.
```sphere.ply``` is a UV sphere generated by Blender.

Current image gives:
![current](https://github.com/mmp/pbrt-v4/assets/68145845/087fa3dc-b74e-4e42-b18f-1535c6715c56)
Expected image:
![expected](https://github.com/mmp/pbrt-v4/assets/68145845/1db92728-281e-40f2-9e7a-8aa3fcadbe50)

The difference is due to quad meshes are not rendered after displacement.