### PR TITLE
Constrain max value test further for unbounded

### DIFF
--- a/src/pbrt/util/spectrum_test.cpp
+++ b/src/pbrt/util/spectrum_test.cpp
@@ -109,7 +109,7 @@ TEST(Spectrum, MaxValue) {
             EXPECT_LE(sr(lambda), m);
 
         RGBUnboundedSpectrum su(*RGBColorSpace::sRGB, 10 * rgb);
-        m = su.MaxValue() * 1.00001f * 10.f;
+        m = su.MaxValue() * 1.00001f;
         for (Float lambda = 360; lambda < 830; lambda += .92)
             EXPECT_LE(su(lambda), m);
 


### PR DESCRIPTION
Removes a 10x multiplier on the maximum value in the MaxValue test for RgbUnboundedSpectrum. The 10x multiplier makes the check unnecessarily lax; the evaluations on the various lambdas below it pass without the multiplier applied.