### PR TITLE
Compatibility with OptiX 8

### DIFF
--- a/src/pbrt/gpu/aggregate.cpp
+++ b/src/pbrt/gpu/aggregate.cpp
@@ -1055,7 +1055,7 @@ OptixPipelineCompileOptions OptiXAggregate::getPipelineCompileOptions() {
     pipelineCompileOptions.exceptionFlags =
         (OPTIX_EXCEPTION_FLAG_STACK_OVERFLOW | OPTIX_EXCEPTION_FLAG_TRACE_DEPTH);
 #if (OPTIX_VERSION < 80000)
-    // This flag is remove since OptiX 8.0.0
+    // This flag is removed since OptiX 8.0.0
     pipelineCompileOptions.exceptionFlags |= OPTIX_EXCEPTION_FLAG_DEBUG;
 #endif
     pipelineCompileOptions.pipelineLaunchParamsVariableName = "params";

--- a/src/pbrt/gpu/aggregate.cpp
+++ b/src/pbrt/gpu/aggregate.cpp
@@ -1053,8 +1053,11 @@ OptixPipelineCompileOptions OptiXAggregate::getPipelineCompileOptions() {
     pipelineCompileOptions.numAttributeValues = 4;
     // OPTIX_EXCEPTION_FLAG_NONE;
     pipelineCompileOptions.exceptionFlags =
-        (OPTIX_EXCEPTION_FLAG_STACK_OVERFLOW | OPTIX_EXCEPTION_FLAG_TRACE_DEPTH |
-         OPTIX_EXCEPTION_FLAG_DEBUG);
+        (OPTIX_EXCEPTION_FLAG_STACK_OVERFLOW | OPTIX_EXCEPTION_FLAG_TRACE_DEPTH);
+#if (OPTIX_VERSION < 80000)
+    // This flag is remove since OptiX 8.0.0
+    pipelineCompileOptions.exceptionFlags |= OPTIX_EXCEPTION_FLAG_DEBUG;
+#endif
     pipelineCompileOptions.pipelineLaunchParamsVariableName = "params";
 
     return pipelineCompileOptions;

--- a/src/pbrt/gpu/denoiser.cpp
+++ b/src/pbrt/gpu/denoiser.cpp
@@ -40,7 +40,9 @@ Denoiser::Denoiser(Vector2i resolution, bool haveAlbedoAndNormal)
     OPTIX_CHECK(optixDeviceContextCreate(cudaContext, 0, &optixContext));
 
     OptixDenoiserOptions options = {};
-#if (OPTIX_VERSION >= 70300)
+#if (OPTIX_VERSION >= 80000)
+    options.denoiseAlpha = OPTIX_DENOISER_ALPHA_MODE_COPY;
+#elif (OPTIX_VERSION >= 70300)
     if (haveAlbedoAndNormal)
         options.guideAlbedo = options.guideNormal = 1;
 
@@ -101,7 +103,9 @@ void Denoiser::Denoise(RGB *rgb, Normal3f *n, RGB *albedo, RGB *result) {
         CUdeviceptr(scratchBuffer), memorySizes.withoutOverlapScratchSizeInBytes));
 
     OptixDenoiserParams params = {};
-#if (OPTIX_VERSION >= 70500)
+#if (OPTIX_VERSION >= 80000)
+    // denoiseAlpha is moved to OptixDenoiserOptions in OptiX 8.0
+#elif (OPTIX_VERSION >= 70500)
     params.denoiseAlpha = OPTIX_DENOISER_ALPHA_MODE_COPY;
 #else
     params.denoiseAlpha = 0;


### PR DESCRIPTION
As per the [release notes](https://developer.nvidia.com/downloads/designworks/optix/secure/8.0.0/optix_release_notes_8.0_01.pdf) of OptiX 8, some APIs have been changed, which break the compilation:
1. The flag `OPTIX_EXCEPTION_FLAG_DEBUG` has been removed;
2. `OptixDenoiserAlphaMode` was moved from `OptixDenoiserParams` to `OptixDenoiserOptions`.

This PR adds version guards for these changes to make PBRT-v4 compatible with OptiX 8.