### PR TITLE
Fixing Time Sampling/Motion Blur for SPPM

### DIFF
--- a/src/pbrt/cpu/integrators.cpp
+++ b/src/pbrt/cpu/integrators.cpp
@@ -2867,6 +2867,8 @@ void SPPMIntegrator::Render() {
             Options->disableWavelengthJitter ? Float(0.5) : RadicalInverse(1, iter);
         const SampledWavelengths passLambda = film.SampleWavelengths(uLambda);
 
+        Float timeSample = samplerPrototype.Get1D();
+
         ParallelFor2D(pixelBounds, [&](Bounds2i tileBounds) {
             // Follow camera paths for _tileBounds_ in image for SPPM
             ScratchBuffer &scratchBuffer = threadScratchBuffers.Get();
@@ -2876,6 +2878,7 @@ void SPPMIntegrator::Render() {
                 // Generate camera ray for pixel for SPPM
                 SampledWavelengths lambda = passLambda;
                 CameraSample cs = GetCameraSample(sampler, pPixel, film.GetFilter());
+                cs.time = timeSample;
                 pstd::optional<CameraRayDifferential> crd =
                     camera.GenerateRayDifferential(cs, lambda);
                 if (!crd || !crd->weight)
@@ -3094,7 +3097,7 @@ void SPPMIntegrator::Render() {
                 // Compute sample values for photon ray leaving light source
                 Point2f uLight0 = Sample2D();
                 Point2f uLight1 = Sample2D();
-                Float uLightTime = camera.SampleTime(Sample1D());
+                Float uLightTime = camera.SampleTime(timeSample);
 
                 // Generate _photonRay_ from light source and initialize _beta_
                 SampledWavelengths lambda = passLambda;

--- a/src/pbrt/cpu/integrators.cpp
+++ b/src/pbrt/cpu/integrators.cpp
@@ -2867,7 +2867,7 @@ void SPPMIntegrator::Render() {
             Options->disableWavelengthJitter ? Float(0.5) : RadicalInverse(1, iter);
         const SampledWavelengths passLambda = film.SampleWavelengths(uLambda);
 
-        Float timeSample = samplerPrototype.Get1D();
+        Float timeSample = RadicalInverse(2, iter);
 
         ParallelFor2D(pixelBounds, [&](Bounds2i tileBounds) {
             // Follow camera paths for _tileBounds_ in image for SPPM


### PR DESCRIPTION
Small changes allow SPPM to converge to the correct image for animated scenes. Before. Rays and photons were individually sampling a separate timestamp leading to many inconsistencies, see #440. This approach can not work without significant changes (e.g. implementing a time kernel). Using a single timestamp per iteration and using it for all rays and photons of that iteration instead provides a straightforward solution to this problem with minimal additions. Because of the numerous iterations/samples of SPPM, it reliably converges to the correct result without any sampling artifacts. I am fairly certain that this is also how they did it in the [original paper](http://graphics.ucsd.edu/~henrik/papers/sppm/stochastic_progressive_photon_mapping.pdf).

Image with Path Tracer Integrator:

![cornell-box_path_gt](https://github.com/user-attachments/assets/261a2d52-7426-42ee-930d-402f01fcd945)

Image with existing SPPM implementation (RMSE: 0.001364; PSNR: 57.31529; SSIM: 0.99679):

![cornell-box-sppm](https://github.com/user-attachments/assets/701467b1-d713-4f26-b4b8-63bc07834afc)

Image with fixed SPPM implementation (RMSE: 0.00074; PSNR: 62.55448; SSIM: 0.99938):

![cornell-box_sppm_fix](https://github.com/user-attachments/assets/88dfcfa0-ba85-49c5-91b3-f31cff4d4e2f)

For reference: I found this issue while working on a seminar paper about Photon Mapping at the Institute of Computer Graphics and Knowledge Visualisation, Graz University of Technology. 

My contact information: 
- Paul Graßler
- paul.grassler@student.tugraz.at - paul.grassler@gmail.com

My supervisor:
- Reinhold Preiner
- https://github.com/rpreiner
- r.preiner@cgv.tugraz.at
- https://www.tugraz.at/institute/cgv/preiner


Scene used in the example images:

```
#Integrator "path"
Integrator "sppm"
    "float radius" [ 0.005 ]
Transform [ 1 -0 -0 -0 -0 1 -0 -0 -0 -0 -1 -0 -0 -1 6.8 1  ]
Sampler "paddedsobol"
    "integer pixelsamples" [ 2048 ]
Film "rgb"
    "string filename" [ "cornell-box.png" ]
    "integer yresolution" [ 1024 ]
    "integer xresolution" [ 1024 ]
Camera "perspective"
    "float fov" [ 19.5 ]
TransformTimes 0 1


WorldBegin

MakeNamedMaterial "LeftWall"
    "string type" [ "diffuse" ]
    "rgb reflectance" [ 0.75 0.25 0.25 ]
MakeNamedMaterial "RightWall"
    "string type" [ "diffuse" ]
    "rgb reflectance" [ 0.25 0.25 0.75 ]
MakeNamedMaterial "Floor"
    "string type" [ "diffuse" ]
    "rgb reflectance" [ 0.725 0.71 0.68 ]
MakeNamedMaterial "Ceiling"
    "string type" [ "diffuse" ]
    "rgb reflectance" [ 0.725 0.71 0.68 ]
MakeNamedMaterial "BackWall"
    "string type" [ "diffuse" ]
    "rgb reflectance" [ 0.725 0.71 0.68 ]
MakeNamedMaterial "ShortBox"
    "string type" [ "diffuse" ]
    "rgb reflectance" [ 0.25 0.75 0.25 ]
MakeNamedMaterial "TallBox"
    "string type" [ "diffuse" ]
    "rgb reflectance" [ 0.25 0.75 0.25 ]
MakeNamedMaterial "Light"
    "string type" [ "diffuse" ]
    "rgb reflectance" [ 0 0 0 ]
NamedMaterial "Floor"
Shape "trianglemesh"
    "point2 uv" [ 0 0 1 0 1 1 0 1 
        ]
    "normal N" [ 4.37114e-8 1 1.91069e-15 4.37114e-8 1 1.91069e-15 4.37114e-8 1 1.91069e-15 
                 4.37114e-8 1 1.91069e-15 ]
    "point3 P" [ -1 1.74846e-7 -1 -1 1.74846e-7 1 1 -1.74846e-7 1 1 -1.74846e-7 -1 ]
    "integer indices" [ 0 1 2 0 2 3 ]
NamedMaterial "Ceiling"
Shape "trianglemesh"
    "point2 uv" [ 0 0 1 0 1 1 0 1 
        ]
    "normal N" [ -8.74228e-8 -1 -4.37114e-8 -8.74228e-8 -1 -4.37114e-8 -8.74228e-8 
                 -1 -4.37114e-8 -8.74228e-8 -1 -4.37114e-8 ]
    "point3 P" [ 1 2 1 -1 2 1 -1 2 -1 1 2 -1 ]
    "integer indices" [ 0 1 2 0 2 3 ]
NamedMaterial "BackWall"
Shape "trianglemesh"
    "point2 uv" [ 0 0 1 0 1 1 0 1 
        ]
    "normal N" [ 8.74228e-8 -4.37114e-8 -1 8.74228e-8 -4.37114e-8 -1 8.74228e-8 -4.37114e-8 
                 -1 8.74228e-8 -4.37114e-8 -1 ]
    "point3 P" [ -1 0 -1 -1 2 -1 1 2 -1 1 0 -1 ]
    "integer indices" [ 0 1 2 0 2 3 ]
NamedMaterial "RightWall"
Shape "trianglemesh"
    "point2 uv" [ 0 0 1 0 1 1 0 1 
        ]
    "normal N" [ 1 -4.37114e-8 1.31134e-7 1 -4.37114e-8 1.31134e-7 1 -4.37114e-8 
                 1.31134e-7 1 -4.37114e-8 1.31134e-7 ]
    "point3 P" [ 1 0 -1 1 2 -1 1 2 1 1 0 1 ]
    "integer indices" [ 0 1 2 0 2 3 ]
NamedMaterial "LeftWall"

AttributeBegin
	Translate 0 1.9 0
	AreaLightSource "diffuse" "rgb L" [ 40 40 40 ] 
	NamedMaterial "Light" 
	Shape "sphere" "float radius" [ 0.1 ] 
AttributeEnd
Shape "trianglemesh"
    "point2 uv" [ 0 0 1 0 1 1 0 1 
        ]
    "normal N" [ -1 -4.37114e-8 -4.37114e-8 -1 -4.37114e-8 -4.37114e-8 -1 -4.37114e-8 
                 -4.37114e-8 -1 -4.37114e-8 -4.37114e-8 ]
    "point3 P" [ -1 0 1 -1 2 1 -1 2 -1 -1 0 -1 ]
    "integer indices" [ 0 1 2 0 2 3 ]


AttributeBegin
    NamedMaterial "ShortBox"
    Translate 0 0.2 0
    ActiveTransform EndTime
    Translate 0 0.2 0
    Shape "sphere"
        "float radius" [ 0.2 ]
AttributeEnd

```