### PR TITLE
Change to use the middle button of the mouse in GUI mode

### DIFF
--- a/src/pbrt/util/gui.cpp
+++ b/src/pbrt/util/gui.cpp
@@ -185,11 +185,11 @@ static void glfwKeyCallback(GLFWwindow* window, int key, int scan, int action, i
 }
 
 void GUI::mouseButtonCallback(GLFWwindow* window, int button, int action, int mods) {
-    if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS) {
+    if (button == GLFW_MOUSE_BUTTON_MIDDLE && action == GLFW_PRESS) {
         pressed = true;
         glfwGetCursorPos(window, &lastX, &lastY);
     }
-    if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_RELEASE) {
+    if (button == GLFW_MOUSE_BUTTON_MIDDLE && action == GLFW_RELEASE) {
         pressed = false;
     }
 }


### PR DESCRIPTION
I have create a proof of concept to add menu options using Imgui so, I need to change the use of the middle mouse button in GUI mode to release the left button to other tasks, like, manage menus.
With the current state, every time that you pick into a option menu, the render is reset
![imagen](https://github.com/user-attachments/assets/601d9e32-d737-47f2-9996-5a5029ba37d1)
