### PR TITLE
Increment splatBuffer pointer by correct amount

### DIFF
--- a/src/pbrt/film.cpp
+++ b/src/pbrt/film.cpp
@@ -882,7 +882,7 @@ SpectralFilm::SpectralFilm(FilmBaseParameters p, Float lambdaMin, Float lambdaMa
         pixel.weightSums = bucketWeightBuffer;
         bucketWeightBuffer += nBuckets;
         pixel.bucketSplats = splatBuffer;
-        splatBuffer += NSpectrumSamples;
+        splatBuffer += nBuckets;
     }
 }
 


### PR DESCRIPTION
This pointer should be incremented by nBuckets, and not NSpectrumSamples.

This should fix issue #450.