### PR TITLE
Fix CMake build error on Windows 10 by exporting zlibstatic alongside Ptex_static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1032,6 +1032,17 @@ add_sanitizers (nanovdb2pbrt)
 
 set_property (TARGET nanovdb2pbrt PROPERTY FOLDER "cmd")
 
+# Only do this if both targets actually exist
+if (TARGET Ptex_static AND TARGET zlibstatic)
+  install(
+    TARGETS zlibstatic
+    EXPORT Ptex             # Same export set name as used by Ptex
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+  )
+endif()
+
 ######################
 # cyhair2pbrt
 


### PR DESCRIPTION
The related open issue: #467 

* Adds a post-configuration step that explicitly installs `zlibstatic` into the `Ptex` export set.
* Prevents "target not in any export set" errors during the installation stage.
* Leaves the existing Ptex submodule files unmodified, preserving upstream compatibility.
* Verified on Windows 10 with Visual Studio 2022.