### PR TITLE
Fix NAN bug when MLT propose a path with 0 radiance

### DIFF
--- a/src/pbrt/cpu/integrators.cpp
+++ b/src/pbrt/cpu/integrators.cpp
@@ -2679,12 +2679,33 @@ void MLTIntegrator::Render() {
             // Compute acceptance probability for proposed sample
             Float cProposed = c(LProposed, lambdaProposed);
             Float cCurrent = c(LCurrent, lambdaCurrent);
-            Float accept = std::min<Float>(1, cProposed / cCurrent);
 
-            // Splat both current and proposed samples to _film_
-            if (accept > 0)
-                film.AddSplat(pProposed, LProposed * accept / cProposed, lambdaProposed);
-            film.AddSplat(pCurrent, LCurrent * (1 - accept) / cCurrent, lambdaCurrent);
+            Float accept = NAN;
+            if (cProposed == 0 && cCurrent == 0) {
+                // neither current path or the proposed found a light source
+                accept = 0.5;
+
+            } else if (cProposed == 0) {
+                // current path found a light source but the proposed didn't
+                accept = 0;
+                film.AddSplat(pCurrent, LCurrent / cCurrent, lambdaCurrent);
+
+            } else if (cCurrent == 0) {
+                // current path didn't find a light source but the proposed did
+                accept = 1;
+                film.AddSplat(pCurrent, LCurrent / cProposed, lambdaCurrent);
+
+            } else {
+                // both paths found a light source
+                 accept = std::min<Float>(1, cProposed / cCurrent);
+                // Splat both current and proposed samples to _film_
+                if (accept > 0) {
+                    film.AddSplat(pProposed, LProposed * accept / cProposed, lambdaProposed);
+                }
+                if (accept < 1) {
+                    film.AddSplat(pCurrent, LCurrent * (1 - accept) / cCurrent, lambdaCurrent);
+                }
+            }
 
             // Accept or reject the proposal
             if (rng.Uniform<Float>() < accept) {


### PR DESCRIPTION
In [MLTIntegrator::Render()](https://github.com/mmp/pbrt-v4/blob/88645ffd6a451bd030d062a55a70a701c58a55d0/src/pbrt/cpu/integrators.cpp#L2679C1-L2687C88), when computing radiance for current path and proposed path, there is non zero probabilty that their radiance (`cCurrent`, `cProposed`) evaluated to 0.

In such case, both `accept` and splat value will be affected:
* `accept` will be assigned `1` when `cCurrent == 0`
*  `LProposed * accept / cProposed` and `LCurrent * (1 - accept) / cCurrent` will be evaluated to NAN, thus pollute the final image

```cpp
Float cProposed = c(LProposed, lambdaProposed);
Float cCurrent = c(LCurrent, lambdaCurrent);
Float accept = std::min<Float>(1, cProposed / cCurrent);

// Splat both current and proposed samples to _film_
if (accept > 0)
    film.AddSplat(pProposed, LProposed * accept / cProposed, lambdaProposed);
film.AddSplat(pCurrent, LCurrent * (1 - accept) / cCurrent, lambdaCurrent);
```

The fix is simple: just avoid `film.AddSplat()` when `cCurrent == 0 || cProposed == 0`, and then compute `accept` specifically.