### PR TITLE
Redo cmake/OpenEXR integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,7 @@
 	url = https://github.com/nothings/stb.git
 [submodule "src/ext/openexr"]
 	path = src/ext/openexr
-	url = https://github.com/mmp/openexr.git
-	branch = zlibstatic-export-workaround
+	url = https://github.com/AcademySoftwareFoundation/openexr
 [submodule "src/ext/filesystem"]
 	path = src/ext/filesystem
 	url = https://github.com/wjakob/filesystem.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ function (CHECK_EXT NAME DIR HASH)
   endif (GIT_FOUND)
 endfunction ()
 
-check_ext ("OpenEXR" "openexr/OpenEXR" ca757f97033ae7cfcc6130f23c0e9ee86b108b07)
+check_ext ("OpenEXR" "openexr/src" f723c3940fff287c0a26b425b90a8e764823bfd4)
 check_ext ("OpenVDB" "openvdb/nanovdb" 414bed84c2fc22e188eac7b611aa85c7edd7a5a9)
 check_ext ("Ptex" "ptex/src" 054047d02b9e06e690420b407114d2872435b953)
 check_ext ("double-conversion" "double-conversion/cmake" cc1f75a114aca8d2af69f73a5a959aecbab0e87a)
@@ -104,6 +104,17 @@ endif ()
 set (BUILD_SHARED_LIBS OFF)
 
 add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/src/ext)
+
+find_package(OpenEXR 3.1.1)
+
+if (OPENEXR_FOUND)
+  message (STATUS "Found OpenEXR version ${OPENEXR_VERSION}")
+else ()
+  message (STATUS "OpenEXR not found; building it from scratch.")
+  add_subdirectory (src/ext/openexr)
+  set_property (TARGET IlmThread Iex OpenEXR
+                PROPERTY FOLDER "ext/OpenEXR")
+endif ()
 
 ########################################
 # os/compiler-specific stuff
@@ -857,7 +868,6 @@ target_include_directories (pbrt_lib PUBLIC
   src/ext
   ${STB_INCLUDE}
   ${QOI_INCLUDE}
-  ${OPENEXR_INCLUDE}
   ${ZLIB_INCLUDE_DIRS}
   ${LIBDEFLATE_INCLUDE_DIRS}
   ${FILESYSTEM_INCLUDE}
@@ -875,7 +885,7 @@ endif ()
 
 target_compile_options (pbrt_lib PUBLIC ${PBRT_CXX_FLAGS})
 
-target_link_libraries (pbrt_lib PRIVATE pbrt_warnings pbrt_opt $<$<BOOL:PBRT_CUDA_ENABLED>:cuda_build_configuration>)
+target_link_libraries (pbrt_lib PRIVATE OpenEXR::OpenEXR pbrt_warnings pbrt_opt $<$<BOOL:PBRT_CUDA_ENABLED>:cuda_build_configuration>)
 
 add_sanitizers (pbrt_lib)
 
@@ -887,7 +897,7 @@ endif()
 set (ALL_PBRT_LIBS
   pbrt_lib
   ${CMAKE_THREAD_LIBS_INIT}
-  ${OPENEXR_LIBS}
+  OpenEXR::OpenEXR
   Ptex_static
   ${ZLIB_LIBRARIES}
   ${LIBDEFLATE_LIBRARIES}

--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -55,53 +55,9 @@ set (ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS} PARENT_SCOPE)
 set (ZLIB_LIBRARIES ${ZLIB_LIBARIES} PARENT_SCOPE)
 
 ###########################################################################
-# OpenEXR
+# openexr
 
-find_package (OpenEXR)
-
-if (OPENEXR_FOUND)
-  message (STATUS "Found OpenEXR version ${OPENEXR_VERSION}")
-  set (OPENEXR_INCLUDE ${OPENEXR_INCLUDES}/OpenEXR ${ILMBASE_INCLUDES}/OpenEXR PARENT_SCOPE)
-  if (WIN32)
-    set (OPENEXR_LIBS ${OPENEXR_LIBRARIES} ${ZLIB_LIBRARY} PARENT_SCOPE)
-  else ()
-    set (OPENEXR_LIBS ${OPENEXR_LIBRARIES} PARENT_SCOPE)
-  endif ()
-else ()
-  message (STATUS "OpenEXR not found; building it from scratch.")
-
-  SET (CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-
-  set (ILMBASE_NAMESPACE_VERSIONING OFF CACHE BOOL " " FORCE)
-  set (OPENEXR_NAMESPACE_VERSIONING OFF CACHE BOOL " " FORCE)
-  set (OPENEXR_BUILD_SHARED_LIBS    OFF CACHE BOOL " " FORCE)
-  set (ILMBASE_BUILD_SHARED_LIBS    OFF CACHE BOOL " " FORCE)
-  set (PYILMBASE_ENABLE             OFF CACHE BOOL " " FORCE)
-  set (OPENEXR_BUILD_UTILS          OFF CACHE BOOL " " FORCE)
-
-  add_subdirectory (openexr)
-
-  set_property (TARGET IexMath IlmThread Half
-                Iex Imath IlmImf HalfTest IexTest
-                IlmImfExamples IlmImfTest IlmImfUtil IlmImfUtilTest ImathTest
-                PROPERTY FOLDER "ext/OpenEXR")
-
-  set (OPENEXR_INCLUDE
-    ${CMAKE_CURRENT_SOURCE_DIR}/openexr/IlmBase/Imath
-    ${CMAKE_CURRENT_SOURCE_DIR}/openexr/IlmBase/Half
-    ${CMAKE_CURRENT_SOURCE_DIR}/openexr/IlmBase/Iex
-    ${CMAKE_CURRENT_SOURCE_DIR}/openexr/OpenEXR/IlmImf
-    ${CMAKE_CURRENT_BINARY_DIR}/openexr/IlmBase/config
-    ${CMAKE_CURRENT_BINARY_DIR}/openexr/OpenEXR/config
-  PARENT_SCOPE
-  )
-
-  if (WIN32)
-    set (OPENEXR_LIBS OpenEXR::IlmImf IlmBase::Imath IlmBase::Half ${ZLIB_LIBRARY} PARENT_SCOPE)
-  else ()
-    set (OPENEXR_LIBS OpenEXR::IlmImf IlmBase::Imath IlmBase::Half PARENT_SCOPE)
-  endif ()
-endif ()
+find_package(OpenEXR)
 
 ###########################################################################
 # ptex


### PR DESCRIPTION
Use the "modern" cmake way of naming/passing along targets; as a bonus, this lets us bump the version of openexr we ship as a submodule to be the most recent release.

Fixes #478, which was due to pbrt not handling having a modern version of openexr installed locally.