### PR TITLE
Fix CMake build error finding OpenEXR package

### DIFF
--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -53,11 +53,8 @@ endif ()
 
 set (ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS} PARENT_SCOPE)
 set (ZLIB_LIBRARIES ${ZLIB_LIBARIES} PARENT_SCOPE)
-
-###########################################################################
-# openexr
-
-find_package(OpenEXR)
+set (ZLIB_INCLUDE_DIR ${ZLIB_INCLUDE_DIR} PARENT_SCOPE)
+set (ZLIB_LIBRARY ${ZLIB_LIBRARY} PARENT_SCOPE)
 
 ###########################################################################
 # ptex


### PR DESCRIPTION
Fixes: #467 

``find_package(OpenEXR)`` was called twice, once in the main CMakeLists.txt and another in src/ext/CMakeLists.txt. Also, when OpenEXR and ZLib are not installed in the system, trying to find the package OpenEXR in the main CMake failed with the error: "``missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR``" because the variables were not in the scope.