### PR TITLE
Fix Zlib related error typo in CMakeLists.txt

### DIFF
--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -52,7 +52,7 @@ if (NOT ZLIB_FOUND)
 endif ()
 
 set (ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS} PARENT_SCOPE)
-set (ZLIB_LIBRARIES ${ZLIB_LIBARIES} PARENT_SCOPE)
+set (ZLIB_LIBRARIES ${ZLIB_LIBRARIES} PARENT_SCOPE)
 
 ###########################################################################
 # openexr


### PR DESCRIPTION
Seems that after fixing this error typo, the proposal to fix OpenEXR issues here https://github.com/mmp/pbrt-v4/pull/490 aren't unnecessary