### PR TITLE
Fix CUDA 13.x Compatibility in PBRT-v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 src/build
 .DS_Store
 .ipynb_checkpoints/
-build/
+*build*/
 .cache/

--- a/src/pbrt/gpu/memory.cpp
+++ b/src/pbrt/gpu/memory.cpp
@@ -61,8 +61,16 @@ void CUDATrackedMemoryResource::PrefetchToGPU() const {
     LOG_VERBOSE("Prefetching %d allocations to GPU memory", allocations.size());
     size_t bytes = 0;
     for (auto iter : allocations) {
+    #if CUDART_VERSION >= 13000
+        cudaMemLocation location = {};
+        location.type = cudaMemLocationTypeDevice;
+        location.id = deviceIndex;
+        CUDA_CHECK(
+            cudaMemPrefetchAsync(iter.first, iter.second, location, 0 /* stream */));
+    #else
         CUDA_CHECK(
             cudaMemPrefetchAsync(iter.first, iter.second, deviceIndex, 0 /* stream */));
+    #endif
         bytes += iter.second;
     }
     CUDA_CHECK(cudaDeviceSynchronize());

--- a/src/pbrt/gpu/util.cpp
+++ b/src/pbrt/gpu/util.cpp
@@ -48,11 +48,19 @@ void GPUInit() {
         CUDA_CHECK(cudaGetDeviceProperties(&deviceProperties, i));
         CHECK(deviceProperties.canMapHostMemory);
 
+    #if CUDART_VERSION >= 13000
+        int clockRateKHz = 0;
+        cudaDeviceGetAttribute(&clockRateKHz, cudaDevAttrClockRate, i);
+        float clockRate = clockRateKHz;
+    #else
+        float clockRate = deviceProperties.clockRate;
+    #endif
+
         std::string deviceString = StringPrintf(
             "CUDA device %d (%s) with %f MiB, %d SMs running at %f MHz "
             "with shader model %d.%d",
             i, deviceProperties.name, deviceProperties.totalGlobalMem / (1024. * 1024.),
-            deviceProperties.multiProcessorCount, deviceProperties.clockRate / 1000.,
+            deviceProperties.multiProcessorCount, clockRate / 1000.,
             deviceProperties.major, deviceProperties.minor);
         LOG_VERBOSE("%s", deviceString);
         devices += deviceString + "\n";


### PR DESCRIPTION
This pull request resolves build errors when compiling with CUDA 13.x, since the API has changed.

Fixed Build Errors:
```
src/pbrt/wavefront/integrator.cpp(629): error: no suitable constructor exists to convert from "int" to "cudaMemLocation"
src/pbrt/wavefront/integrator.cpp(631): error: no suitable constructor exists to convert from "int" to "cudaMemLocation"
src/pbrt/gpu/util.cpp(56): error: class "cudaDeviceProp" has no member "clockRate"
src/pbrt/gpu/memory.cpp(71): error: no suitable constructor exists to convert from "int" to "cudaMemLocation"
```

Solution:
- Wrapped changes with `#if CUDART_VERSION >= 13000` to maintain backward compatibility.
- Updated `cudaMemPrefetchAsync` calls to use the `cudaMemLocation` struct.
- Used `cudaDeviceGetAttribute` for `clockRate` access.

Testing:
- Successfully compiled PBRT-v4 with CUDA 13.0 on Fedora 42.
- Successfully rendered several scenes with the Nvidia GPU.