### PR TITLE
Negative Refractive Index

### DIFF
--- a/src/pbrt/util/math.h
+++ b/src/pbrt/util/math.h
@@ -284,6 +284,15 @@ inline double SafeSqrt(double x) {
     return std::sqrt(std::max(0., x));
 }
 
+PBRT_CPU_GPU inline float Abs(float x) {
+    return std::abs(x);
+}
+
+PBRT_CPU_GPU
+inline double Abs(double x) {
+    return std::abs(x);
+}
+
 template <typename T>
 PBRT_CPU_GPU inline constexpr T Sqr(T v) {
     return v * v;

--- a/src/pbrt/util/scattering.h
+++ b/src/pbrt/util/scattering.h
@@ -60,6 +60,8 @@ PBRT_CPU_GPU inline Float HenyeyGreenstein(Float cosTheta, Float g) {
 // Fresnel Inline Functions
 PBRT_CPU_GPU inline Float FrDielectric(Float cosTheta_i, Float eta) {
     cosTheta_i = Clamp(cosTheta_i, -1, 1);
+    // Allow negative IOR values
+    eta = Abs(eta);
     // Potentially flip interface orientation for Fresnel equations
     if (cosTheta_i < 0) {
         eta = 1 / eta;


### PR DESCRIPTION
This PR introduces a small fix to `FrDielectric` to properly handle negative indices of refraction (IOR). While the interpretation of `eta` changes slightly for left-handed media, its value remains positive. This enables physically meaningful visualization of negative-index (metamaterial) materials.

For background, see “Negative Refractive Index Materials” ([J. Comput. Theor. Nanosci. 3, 2006](https://doi.org/10.1166/jctn.2006.3000), there is a free pdf on google scholar).

Visual Comparison:
**IOR = ±1.5** (negative on the left)
<img width="600" height="400" alt="simple_bdpt-neg_ior_15" src="https://github.com/user-attachments/assets/6bb8b176-7505-4a7c-b308-d0841f9fc6ac" />

**IOR = ±1.0** (negative on the left, positive on the right—visible only due to SDS paths)
<img width="600" height="400" alt="simple_bdpt-neg_ior_10" src="https://github.com/user-attachments/assets/36ccdd74-f18f-466c-bfab-5deeabb88d8d" />
