### PR TITLE
Fix division-by-zero in null-scattering PDF computation for participating media

### DIFF
--- a/src/pbrt/cpu/integrators.cpp
+++ b/src/pbrt/cpu/integrators.cpp
@@ -1058,9 +1058,11 @@ SampledSpectrum VolPathIntegrator::Li(RayDifferential ray, SampledWavelengths &l
                         SampledSpectrum sigma_n =
                             ClampZero(sigma_maj - mp.sigma_a - mp.sigma_s);
                         Float pdf = T_maj[0] * sigma_n[0];
-                        beta *= T_maj * sigma_n / pdf;
-                        if (pdf == 0)
+                        if (pdf == 0) {
                             beta = SampledSpectrum(0.f);
+                            return false;
+                        }
+                        beta *= T_maj * sigma_n / pdf;
                         r_u *= T_maj * sigma_n / pdf;
                         r_l *= T_maj * sigma_maj / pdf;
                         return beta && r_u;
@@ -2039,10 +2041,11 @@ int RandomWalk(const Integrator &integrator, SampledWavelengths &lambda,
                         SampledSpectrum sigma_n =
                             ClampZero(sigma_maj - mp.sigma_a - mp.sigma_s);
                         Float pdf = T_maj[0] * sigma_n[0];
-                        if (pdf == 0)
+                        if (pdf == 0) {
                             beta = SampledSpectrum(0.f);
-                        else
-                            beta *= T_maj * sigma_n / pdf;
+                            return false;
+                        }
+                        beta *= T_maj * sigma_n / pdf;
                         return bool(beta);
                     }
                 });

--- a/src/pbrt/wavefront/intersect.h
+++ b/src/pbrt/wavefront/intersect.h
@@ -206,6 +206,10 @@ inline PBRT_CPU_GPU void TraceTransmittance(ShadowRayWorkItem sr,
 
                     // ratio-tracking: only evaluate null scattering
                     Float pr = T_maj[0] * sigma_maj[0];
+                    if (pr == 0) {
+                        T_ray = SampledSpectrum(0.f);
+                        return false;
+                    }
                     T_ray *= T_maj * sigma_n / pr;
                     r_l *= T_maj * sigma_maj / pr;
                     r_u *= T_maj * sigma_n / pr;

--- a/src/pbrt/wavefront/media.cpp
+++ b/src/pbrt/wavefront/media.cpp
@@ -127,9 +127,11 @@ void WavefrontPathIntegrator::SampleMediumInteraction(int wavefrontDepth) {
                             ClampZero(sigma_maj - mp.sigma_a - mp.sigma_s);
 
                         Float pr = T_maj[0] * sigma_n[0];
-                        beta *= T_maj * sigma_n / pr;
-                        if (pr == 0)
+                        if (pr == 0) {
                             beta = SampledSpectrum(0.f);
+                            return false;
+                        }
+                        beta *= T_maj * sigma_n / pr;
                         r_u *= T_maj * sigma_n / pr;
                         r_l *= T_maj * sigma_maj / pr;
 


### PR DESCRIPTION
## Summary

Fix division-by-zero bugs in the null-scattering path of participating media sampling. When the null-scattering PDF (`T_maj[0] * sigma_n[0]` or `T_maj[0] * sigma_maj[0]`) evaluates to zero, the original code performs division before checking the zero condition, producing NaN/Inf values that propagate through `beta`, `r_u`, `r_l`, and `T_ray`, corrupting the entire path contribution and potentially causing rendering artifacts.

This PR moves the zero-check **before** the division and immediately returns `false` to terminate the path, avoiding any undefined arithmetic.

## Changes

### CPU integrators (`src/pbrt/cpu/integrators.cpp`)
- **`VolPathIntegrator::Li`** (null-scattering callback): Check `pdf == 0` before dividing `beta`, `r_u`, `r_l` by `pdf`. Set `beta` to zero and return `false` early.
- **`RandomWalk`** (null-scattering callback): Same fix — check `pdf == 0` first, set `beta` to zero and return `false` instead of conditionally skipping only the `beta` update.

### Wavefront media sampling (`src/pbrt/wavefront/media.cpp`)
- **`WavefrontPathIntegrator::SampleMediumInteraction`** (null-scattering callback): Check `pr == 0` before dividing `beta`, `r_u`, `r_l` by `pr`. Set `beta` to zero and return `false` early.

### Wavefront transmittance (`src/pbrt/wavefront/intersect.h`)
- **`TraceTransmittance`** (ratio-tracking null-scattering): Add `pr == 0` guard before dividing `T_ray`, `r_l`, `r_u` by `pr`. Set `T_ray` to zero and return `false` early.

## Motivation

In scenes with participating media, it is possible for the null-scattering probability `T_maj * sigma_n` (or `T_maj * sigma_maj`) to evaluate to exactly zero. The original code either:
1. Divides first, then checks for zero (CPU path, wavefront media), or
2. Has no zero-check at all (wavefront transmittance).

Both cases lead to NaN/Inf propagation, which can cause visible fireflies, black pixels, or assertion failures depending on the scene configuration and medium parameters.