### PR TITLE
Fix small correctness issues in util containers

### DIFF
--- a/src/pbrt/util/containers.h
+++ b/src/pbrt/util/containers.h
@@ -659,7 +659,7 @@ class HashMap {
         PBRT_CPU_GPU
         std::pair<Key, Value> *operator->() { return &ptr->value(); }
         PBRT_CPU_GPU
-        const std::pair<Key, Value> *operator->() const { return ptr->value(); }
+        const std::pair<Key, Value> *operator->() const { return &ptr->value(); }
 
       private:
         friend class HashMap;

--- a/src/pbrt/util/containers.h
+++ b/src/pbrt/util/containers.h
@@ -591,7 +591,7 @@ class InlinedVector {
 
     void resize(size_type n) {
         if (n < size()) {
-            for (size_t i = n; n < size(); ++i)
+            for (size_t i = n; i < size(); ++i)
                 alloc.destroy(begin() + i);
         } else if (n > size()) {
             reserve(n);

--- a/src/pbrt/util/containers.h
+++ b/src/pbrt/util/containers.h
@@ -226,6 +226,7 @@ class Array2D {
             values = allocator.allocate_object<T>(no);
             for (int i = 0; i < no; ++i)
                 allocator.construct(values + i, other.values[i]);
+            extent = other.extent;
         }
         return *this;
     }


### PR DESCRIPTION
This PR fixes three small correctness issues in `src/pbrt/util/containers.h`.

  - Fix `Array2D` move assignment when allocators differ and the extent changes.
    The storage was reallocated and values were copied from `other`, but `extent` was not updated, leaving the object
  with stale dimensions.

  - Fix `InlinedVector::resize()` when shrinking.
    The loop condition used `n < size()` instead of `i < size()`, so shrinking could destroy past the valid range.

  - Fix `HashMap::Iterator::operator->() const`.
    The const overload returns a pointer type but returned `ptr->value()` instead of `&ptr->value()`, unlike the non-
  const overload.